### PR TITLE
Defer using process.nextTick

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,6 +140,15 @@ internals.Podium.prototype._emit = function (criteria, data, generated, callback
     internals.emit(this, { criteria, data, callback, generated });
 };
 
+const itemCallback = function (item) {
+
+    item.callback();
+};
+
+const emitEmitter = function (emitter) {
+
+    internals.emit(emitter);
+};
 
 internals.emit = function (emitter, notification) {
 
@@ -162,11 +171,11 @@ internals.emit = function (emitter, notification) {
     const finalize = () => {
 
         if (item.callback) {
-            setImmediate(() => item.callback());
+            process.nextTick(itemCallback, item);
         }
 
         emitter._eventsProcessing = false;
-        setImmediate(() => internals.emit(emitter));
+        process.nextTick(emitEmitter, emitter);
     };
 
     let data = item.data;


### PR DESCRIPTION
Fixes https://github.com/hapijs/hapi/issues/3347.

I have used top-level functions to avoid allocating closures in a hot path.