### PR TITLE
Fixed Typos and Added formatting to note key details

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,28 +24,28 @@ Returns a `Podium` object.
 Register the specified events and their optional configuration. Events must be registered before
 they can be emitted or subscribed to. This is done to detect event name mispelling and invalid
 event activities. The `events` argument can be:
-- an event string.
+- an event **string**.
 - an event options object with the following optional keys (unless noted otherwise):
-    - `name` - the event name string (required).
-    - `channels` - a string or array of strings specifying the event channels available. Defaults
-       to no channel restrictions (event updates can specify a channel or not).
+    - `name` - the event name **string (required)**.
+    - `channels` - a **string** or **array of strings** specifying the event channels available. **Defaults
+       to no channel restrictions (event updates can specify a channel or not).**
     - `clone` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
         is cloned before it is passed to the listeners (unless an override specified by each listener).
-        Defaults to `false` (`data` is passed as-is).
+        **Defaults to `false` (`data` is passed as-is).**
     - `spread` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
-        must be an array and the `listener` method is called with each array element passed as a separate
-        argument (unless an override specified by each listener). This should only be used when the emitted
-        data structure is known and predictable.
-        Defaults to `false` (`data` is emitted as a single argument regardless of its type).
+        **must be an array** and the `listener` method is called with each array element passed as a separate
+        argument (unless an override specified by each listener). **This should only be used when the emitted
+        data structure is known and predictable.**
+        **Defaults to `false` (`data` is emitted as a single argument regardless of its type).**
     - `tags` - if `true` and the `criteria` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
         includes `tags`, the tags are mapped to an object (where each tag string is the key and
         the value is `true`) which is appended to the arguments list at the end (but before
         the `callback` argument if `block` is set). A configuration override can be set by each
-        listener. Defaults to `false`.
+        listener. **Defaults to `false`.**
     - `shared` - if `true`, the same event `name` can be registered multiple times where the second
-      registration is ignored. Note that if the registration config is changed between registrations,
+      registration is ignored. **Note that if the registration config is changed between registrations,
       only the first configuration is used. Defaults to `false` (a duplicate registration will throw an
-      error).
+      error).**
 - a `Podium` object which is passed to [`podium.registerPodium()`](#podiumregisterpodiumpodiums).
 - an array containing any of the above.
 
@@ -68,49 +68,49 @@ Emits an event update to all the subscribed listeners where:
         - `channel` - the channel name string.
         - `tags` - a tag string or array of tag strings.
 - `data` - the value emitted to the subscribers.
-- `callback` - an optional callback method invoked when all subscribers have been notified using the
+- `callback` - an **optional** callback method invoked when all subscribers have been notified using the
   signature `function()`.
 
 ## `podium.on(criteria, listener)`
 
 Subscribe a handler to an event where:
-- `criteria` - the subscription criteria which must be one of:
-    - event name string.
+- `criteria` - the subscription criteria which must be one of the following:
+    - event name **string**.
     - a criteria object with the following optional keys (unless noted otherwise):
-        - `name` - the event name string (required).
+        - `name` - the event name **string (required)**.
         - `block` - if `true`, the `listener` method receives an additional `callback` argument
           which must be called when the method completes. No other event will be emitted until the
           `callback` methods is called. The method signature is `function()`. If `block` is set to
           a positive integer, the value is used to set a timeout after which any pending events
-          will be emitted, ignoring the eventual call to `callback`. Defaults to `false` (non
-          blocking).
-        - `channels` - a string or array of strings specifying the event channels to subscribe to.
+          will be emitted, ignoring the eventual call to `callback`. **Defaults to `false` (non
+          blocking).**
+        - `channels` - a **string** or **array of strings** specifying the event channels to subscribe to.
           If the event registration specified a list of allowed channels, the `channels` array must
           match the allowed channels. If `channels` are specified, event updates without any
-          channel designation will not be included in the subscription. Defaults to no channels
-          filter.
+          channel designation will not be included in the subscription. **Defaults to no channels
+          filter.**
         - `clone` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
-           is cloned before it is passed to the `listener` method. Defaults to the event
-           registration option (which defaults to `false`).
-        - `count` - a positive integer indicating the number of times the `listener` can be called
+           is cloned before it is passed to the `listener` method. **Defaults to the event
+           registration option (which defaults to `false`).**
+        - `count` - a positive **integer** indicating the number of times the `listener` can be called
           after which the subscription is automatically removed. A count of `1` is the same as
-          calling `podium.once()`. Defaults to no limit.
-        - `filter` - the event tags (if present) to subscribe to which can be one of:
-            - a tag string.
-            - an array of tag strings.
+          calling `podium.once()`. **Defaults to no limit.**
+        - `filter` - the event tags (if present) to subscribe to which can be one of the following:
+            - a tag **string**.
+            - an **array** of tag **strings**.
             - an object with the following:
-                - `tags` - a tag string or array of tag strings.
+                - `tags` - a tag **string** or **array** of tag **strings**.
                 - `all` - if `true`, all `tags` must be present for the event update to match the
-                  subscription. Defaults to `false` (at least one matching tag).
+                  subscription. **Defaults to `false` (at least one matching tag).**
         - `spread` - if `true`, and the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
-          is an array, the `listener` method is called with each array element passed as a separate
-          argument. This should only be used when the emitted data structure is known and predictable.
-          Defaults to the event registration option (which defaults to `false`).
+          is an **array**, the `listener` method is called with each **array element** passed as a separate
+          argument. **This should only be used when the emitted data structure is known and predictable.
+          Defaults to the event registration option (which defaults to `false`).**
         - `tags` - if `true` and the `criteria` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
           includes `tags`, the tags are mapped to an object (where each tag string is the key and
           the value is `true`) which is appended to the arguments list at the end (but before
-          the `callback` argument if `block` is set). Defaults to the event registration option
-          (which defaults to `false`).
+          the `callback` argument if `block` is set). **Defaults to the event registration option
+          (which defaults to `false`).**
 - `listener` - the handler method set to receive event updates. The function signature depends
   on the `block`, `spread`, and `tags` options.
 
@@ -125,7 +125,7 @@ Same as calling [`podium.on()`](#podiumoncriteria-listener) with the `count` opt
 ## `podium.removeListener(name, listener)`
 
 Removes all listeners subscribed to a given event name matching the provided listener method where:
-- `name` - the event name string.
+- `name` - the event name **string**.
 - `listener` - the function reference provided when subscribed.
 
 Returns a reference to the current emitter.
@@ -133,13 +133,13 @@ Returns a reference to the current emitter.
 ## `podium.removeAllListeners(name)`
 
 Removes all listeners subscribed to a given event name where:
-- `name` - the event name string.
+- `name` - the event name **string**.
 
 Returns a reference to the current emitter.
 
 ## `podium.hasListeners(name)`
 
 Returns whether an event has any listeners subscribed where:
-- `name` - the event name string.
+- `name` - the event name **string**.
 
 Returns `true` if the event name has any listeners, otherwise `false`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Node (semi) compatible event emitter with extra features.
 arguments spreading, and other features useful when building large scale applications.
 While node's native [`EventEmitter`](https://nodejs.org/dist/latest-v6.x/docs/api/events.html#events_class_eventemitter) is strictly focused on maximum performance,
 it lacks many features that do not belong in the core implementation. **podium** is not restricted by
-node's performance requirement as it is designed for application layer needs where it's overhead
+node's performance requirement as it is designed for application layer needs where its overhead
 is largely insignificant as implementing these features will have similar cost on top of the native emitter.
 
 [![Build Status](https://secure.travis-ci.org/hapijs/podium.svg)](http://travis-ci.org/hapijs/podium)
@@ -48,7 +48,7 @@ podiumObject.registerEvent({
 
 ## `podium.on(criteria, listener)`
 
-Subscribe a handler to an event. Handler can be seen a function which will be called when the event occurs.
+Subscribe a handler to an event. Handler can be seen as a function which will be called when the event occurs.
 
 ```javascript
 podiumObject.registerEvent('event1');
@@ -74,8 +74,8 @@ podiumObject.addListener('event1', listener1);
 
 ## `podium.once(criteria, listener)`
 
-Same as calling podium.on() with the count option set to 1. Whenever we call emit(), `listener1` will get fired
-but also get removed, so that it won't get fired on call to emit().
+Same as calling `podium.on()` with the count option set to 1. Whenever we call `emit()`, `listener1` will get fired
+but also get removed, so that it won't get fired on call to `emit()`.
 
 ```javascript
 podiumObject.once('event1', listener1);
@@ -121,7 +121,7 @@ else{
 
 ## `podium.registerPodium(podiums)`
 
-Registers a podium object(emitter) to another podium object(source). Whenever any event gets registered on `emitterObject` it gets registered on `sourceObject` as well. But reverse is not true.
+Registers a podium object(emitter) to another podium object(source). Whenever any event gets registered on `emitterObject` it gets registered on `sourceObject` as well. But the reverse is not true.
 
 ```javascript
 const source1Object = new Podium('test');


### PR DESCRIPTION
Updated a typo in `README` and added some grammatical touch ups.
Added formatting to `API` and `README` to add contrast and highlight key points.
