### PR TITLE
[update-docs-block-option] Remove references to block options in API

### DIFF
--- a/API.md
+++ b/API.md
@@ -359,8 +359,7 @@ event activities. The `events` argument can be:
         **Defaults to `false` (`data` is emitted as a single argument regardless of its type).**
     - `tags` - if `true` and the `criteria` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
         includes `tags`, the tags are mapped to an object (where each tag string is the key and
-        the value is `true`) which is appended to the arguments list at the end (but before
-        the `callback` argument if `block` is set). A configuration override can be set by each
+        the value is `true`) which is appended to the arguments list at the end. A configuration override can be set by each
         listener. **Defaults to `false`.**
     - `shared` - if `true`, the same event `name` can be registered multiple times where the second
       registration is ignored. **Note that if the registration config is changed between registrations,
@@ -396,12 +395,6 @@ Subscribe a handler to an event where:
     - event name **string**.
     - a criteria object with the following optional keys (unless noted otherwise):
         - `name` - the event name **string (required)**.
-        - `block` - if `true`, the `listener` method receives an additional `callback` argument
-          which must be called when the method completes. No other event will be emitted until the
-          `callback` methods is called. The method signature is `function()`. If `block` is set to
-          a positive integer, the value is used to set a timeout after which any pending events
-          will be emitted, ignoring the eventual call to `callback`. **Defaults to `false` (non
-          blocking).**
         - `channels` - a **string** or **array of strings** specifying the event channels to subscribe to.
           If the event registration specified a list of allowed channels, the `channels` array must
           match the allowed channels. If `channels` are specified, event updates without any
@@ -426,11 +419,10 @@ Subscribe a handler to an event where:
           Defaults to the event registration option (which defaults to `false`).**
         - `tags` - if `true` and the `criteria` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
           includes `tags`, the tags are mapped to an object (where each tag string is the key and
-          the value is `true`) which is appended to the arguments list at the end (but before
-          the `callback` argument if `block` is set). **Defaults to the event registration option
+          the value is `true`) which is appended to the arguments list at the end. **Defaults to the event registration option
           (which defaults to `false`).**
 - `listener` - the handler method set to receive event updates. The function signature depends
-  on the `block`, `spread`, and `tags` options.
+  on the `spread`, and `tags` options.
 - `context` - an **object** that binds to the listener handler.
 
 ## `podium.addListener(criteria, listener, context)`


### PR DESCRIPTION
While trying to use the documented `block` option, I noticed it was no longer available since https://github.com/hapijs/podium/commit/32e5e1c9c3420973f02709bcb5e779cdfc0869a6. The API reference was updated to remove any reference for such option.