### PR TITLE
Add official typescript types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,274 @@
+/**
+ * Node (semi) compatible event emitter with extra features.
+ */
+declare class Podium {
+    /**
+     * Creates a new podium emitter.
+     * 
+     * @param events - If present, the value is passed to podium.registerEvent().
+     */
+    constructor(events?: Podium.Event | Podium.Event[]);
+
+    /**
+     * Register the specified events and their optional configuration. Events must be registered 
+     * before they can be emitted or subscribed to. This is done to detect event name mispelling
+     * and invalid event activities.
+     * 
+     * @param events - The event(s) to register.
+     */
+    registerEvent(events: Podium.Event | Podium.Event[]): void;
+
+    /**
+     * Registers another emitter as an event source for the current emitter (any event update
+     * emitted by the source emitter is passed to any subscriber of the current emitter).
+     * 
+     * Note that any events registered with a source emitter are automatically added to the current
+     * emitter. If the events are already registered, they are left as-is.
+     * 
+     * @param podiums - A Podium object or an array of objects, each added as a source.
+     */
+    registerPodium(podiums: Podium | Podium[]): void;
+
+    /**
+     * Emits an event update to all the subscribed listeners.
+
+     * @param criteria - The event update criteria.
+     * @param data - The value emitted to the subscribers.
+     * 
+     * @returns Promise that resolves when all events has been processed. Any errors will cause an
+     * immediate rejection.
+     */
+    emit(criteria: string | Podium.EmitCriteria, data?: any): Promise<void>;
+
+    /**
+     * Subscribe a handler to an event.
+     * 
+     * @param criteria - The subscription criteria.
+     * @param listener - The handler method set to receive event updates. The function signature
+     *                   depends on the block, spread, and tags options.
+     * @param context - Optional object that binds to the listener handler.
+     *
+     * @returns A reference to the current emitter.
+     */
+    on<Tcontext extends object = this>(criteria: string | Podium.CriteriaObject, listener: Podium.Listener<Tcontext>, context?: Tcontext): this;
+
+    /**
+     * Subscribe a handler to an event. Same as podium.on().
+     *
+     * @param criteria - The subscription criteria.
+     * @param listener - The handler method set to receive event updates. The function signature
+     *                   depends on the block, spread, and tags options.
+     * @param context - Optional object that binds to the listener handler.
+     *
+     * @returns A reference to the current emitter.
+     */
+    addListener<Tcontext extends object = this>(criteria: string | Podium.CriteriaObject, listener: Podium.Listener<Tcontext>, context?: Tcontext): this;
+
+    /**
+     * Same as podium.on() with the count option set to 1.
+     * 
+     * Can also be called without an listener to wait for a single event.
+     * 
+     * @param criteria - The subscription criteria.
+     * @param listener - The handler method set to receive event updates. The function signature
+     *                   depends on the block, spread, and tags options.
+     * @param context - Optional object that binds to the listener handler.
+     *
+     * @returns A reference to the current emitter.
+     */
+    once<Tcontext extends object = this>(criteria: string | Omit<Podium.CriteriaObject, 'count'>, listener: Podium.Listener<Tcontext>, context?: Tcontext): this;
+
+    /**
+     * Wait for a single event. The count option is fixed to 1.
+     * 
+     * @param criteria - The subscription criteria.
+     *
+     * @returns Promise with array of emitted parameters.
+     */
+    once<Tcontext extends void = void>(criteria: string | Omit<Podium.CriteriaObject, 'count'>): Promise<any[]>;
+
+    /**
+     * Removes all listeners subscribed to a given event name matching the provided listener method.
+     * 
+     * @param name - The event name string.
+     * @param listener - The function reference provided when subscribed.
+     * 
+     * @returns A reference to the current emitter.
+     */
+    removeListener(name: string, listener: Podium.Listener<any>): this;
+
+    /**
+     * Removes all listeners subscribed to a given event name.
+     * 
+     * @param name - The event name string.
+     * 
+     * @returns A reference to the current emitter.
+     */
+    removeAllListeners(name: string): this;
+
+    /**
+     * Returns whether an event has any listeners subscribed.
+     * 
+     * @param name  the event name string.
+     * 
+     * @returns true if the event name has any listeners, otherwise false.
+     */
+    hasListeners(name: string): boolean;
+}
+
+declare namespace Podium {
+
+    export interface EmitCriteria { 
+
+        /**
+         * Event name.
+         */
+        readonly name: string;
+
+        /**
+         * Channel name.
+         */
+        readonly channel?: string;
+
+        /**
+         * The tags to apply.
+         */
+        readonly tags?: string | string[] | { [tag: string]: boolean };
+    }
+
+    export interface EventOptions {
+
+        /**
+         * Event name.
+         */
+        readonly name: string;
+
+        /**
+         * A string or array of strings specifying the event channels available.
+         * 
+         * Defaults to no channel restrictions - Event updates can specify a channel or not.
+         */
+        readonly channels?: string | string[];
+
+        /**
+         * Set to make podium.emit() clone the data object passed to it, before it is passed to the
+         * listeners (unless an override specified by each listener).
+         * 
+         * Defaults to false - Data is passed as-is.
+         */
+        readonly clone?: boolean;
+
+        /**
+         * Set to require the data object passed to podium.emit() to be an array, and make the
+         * listener method called with each array element passed as a separate argument (unless an
+         * override specified by each listener).
+         * 
+         * This should only be used when the emitted data structure is known and predictable.
+         * 
+         * Defaults to false - Data is emitted as a single argument regardless of its type.
+         */
+        readonly spread?: boolean;
+
+        /**
+         * Set to make any tags in the critieria object passed to podium.emit() map to an object
+         * (where each tag string is the key and the value is true) which is appended to the emitted
+         * arguments list at the end.
+         * 
+         * A configuration override can be set by each listener.
+         * 
+         * Defaults to false.
+         */
+        readonly tags?: boolean;
+
+        /**
+         * Set to allow the same event name to be registered multiple times, ignoring all but the
+         * first.
+         * 
+         * Note that if the registration config is changed between registrations, only the first
+         * configuration is used.
+         * 
+         * Defaults to false - A duplicate registration will throw an error.
+         */
+        readonly shared?: boolean;
+    }
+
+    type Event = string | EventOptions | Podium;
+
+    type Listener<TContext extends object> =
+        (this: TContext, data?: any, tags?: { [tag: string]: true | undefined }) => void | Promise<void>;
+
+    interface CriteriaFilterOptionsObject {
+
+        /**
+         * A tag string or array of tag strings.
+         */
+        readonly tags?: string | string[];
+
+        /**
+         * Require all tags to be present for the event update to match the subscription.
+         * 
+         * Default false - Require at least one matching tag.
+         */
+        readonly all?: boolean;
+    }
+
+    export interface CriteriaObject {
+
+        /**
+         * Event name.
+         */
+        readonly name: string;
+
+        /**
+         * The event channels to subscribe to.
+         * 
+         * If the event registration specified a list of allowed channels, the channels array must
+         * match the allowed channels. If channels are specified, event updates without any channel
+         * designation will not be included in the subscription.
+         * 
+         * Defaults to no channels filter.
+         */
+        readonly channels?: string | string[];
+
+        /**
+         * Set to clone the data object passed to podium.emit() before it is passed to the listener
+         * method.
+         * 
+         * Defaults to the event registration option (which defaults to false).
+         */
+        readonly clone?: boolean;
+
+        /**
+         * A positive non-zero integer indicating the number of times the listener can be called
+         * after which the subscription is automatically removed.
+         * 
+         * Does nothing when calling once(), where it will use the value 1.
+         * 
+         * Defaults to no limit.
+         */
+        readonly count?: number;
+
+        /**
+         * The event tags (if present) to subscribe to.
+         */
+        readonly filter?: string | string[] | CriteriaFilterOptionsObject;
+
+        /**
+         * Override the value of spread from the event registraiont when the listener is called.
+         * 
+         * This should only be used when the emitted data structure is known and predictable.
+         * 
+         * Defaults to the event registration option (which defaults to false).
+         */
+        readonly spread?: boolean;
+
+        /**
+         * Override the value of tags from the event registraiont when the listener is called.
+         * 
+         * Defaults to the event registration option (which defaults to false).
+         */
+        readonly tags?: boolean;
+    }
+}
+
+export = Podium;

--- a/lib/index.js
+++ b/lib/index.js
@@ -280,7 +280,7 @@ exports = module.exports = internals.Podium = class {
         }
 
         const team = new Teamwork.Team();
-        this.on(criteria, (...args) => team.attend(args), context);
+        this.on(criteria, (...args) => team.attend(args));
         return team.work;
     }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "4.1.1",
   "repository": "git://github.com/hapijs/podium",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],
@@ -18,10 +19,11 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "24.x.x",
+    "typescript": "~4.0.3"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L",
+    "test": "lab -a @hapi/code -t 100 -L -Y",
     "test-cov-html": "lab -r html -o coverage.html -a @hapi/code -L"
   },
   "license": "BSD-3-Clause"

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,123 @@
+import * as Podium from '..';
+import * as Lab from '@hapi/lab';
+
+
+const { expect } = Lab.types;
+
+// Podium()
+
+expect.type<Podium>(new Podium());
+expect.type<Podium>(new Podium('test'));
+expect.type<Podium>(new Podium(['a', { name: 'b', channels: ['c'] }, new Podium()]));
+
+const podium = new Podium();
+
+// registerEvent()
+
+expect.type<void>(podium.registerEvent('test'));
+expect.type<void>(podium.registerEvent(['a', { name: 'b', channels: ['c'] }, new Podium()]));
+
+expect.error(podium.registerEvent());
+expect.error(podium.registerEvent(123));
+expect.error(podium.registerEvent([Symbol()]));
+
+// registerPodium()
+
+expect.type<void>(podium.registerPodium(new Podium()));
+expect.type<void>(podium.registerPodium([new Podium()]));
+
+expect.error(podium.registerPodium());
+expect.error(podium.registerPodium('test'));
+expect.error(podium.registerPodium([{ name: 'test' }]));
+
+// emit()
+
+expect.type<Promise<void>>(podium.emit('test'));
+expect.type<Promise<void>>(podium.emit('test', { data: true }));
+expect.type<Promise<void>>(podium.emit({ name: 'test', channel: 'a', tags: 'b' }, { data: true }));
+expect.type<Promise<void>>(podium.emit({ name: 'test', tags: ['b'] }));
+expect.type<Promise<void>>(podium.emit({ name: 'test', tags: { b: true } }));
+
+expect.error(podium.emit());
+expect.error(podium.emit(123));
+expect.error(podium.emit({ channel: 'a' }));
+expect.error(podium.emit({ name: 123 }));
+expect.error(podium.emit({ name: 'test', channel: 123 }));
+expect.error(podium.emit({ name: 'test', tags: 123 }));
+
+// on()
+
+expect.type<Podium>(podium.on('test', function () { this instanceof Podium; }));
+expect.type<Podium>(podium.on('test', function () { this.ok; }, { ok: true }));
+expect.type<Podium>(podium.on({ name: 'test' }, function () { }));
+expect.type<Podium>(podium.on({ name: 'test', channels: 'a' }, function () { }));
+expect.type<Podium>(podium.on({ name: 'test', filter: 'a' }, function () { }));
+expect.type<Podium>(podium.on({ name: 'test', filter: { all: true, tags: ['a', 'b'] } }, function () { }));
+expect.type<Podium>(podium.on({ name: 'test', tags: true }, function () { }));
+expect.type<Podium>(podium.on({ name: 'test', clone: true }, function () { }));
+expect.type<Podium>(podium.on({ name: 'test', spread: true }, function () { }));
+expect.type<Podium>(podium.on({ name: 'test', count: 3 }, function () { }));
+
+expect.error(podium.on());
+expect.error(podium.on('test'));
+expect.error(podium.on(123, function () { }));
+expect.error(podium.on('test', Podium));
+expect.error(podium.on('test', function () { }), 123);
+expect.error(podium.on('test', function () { this.notOk; }, { ok: true }));
+
+// addListener()
+
+expect.type<Podium>(podium.addListener('test', function () { this instanceof Podium; }));
+expect.type<Podium>(podium.addListener('test', function () { this.ok; }, { ok: true }));
+
+expect.error(podium.addListener());
+expect.error(podium.addListener('test'));
+expect.error(podium.addListener(123, function () { }));
+expect.error(podium.addListener('test', Podium));
+expect.error(podium.addListener('test', function () { this.notOk; }, { ok: true }));
+expect.error(podium.once({ name: 'test', unknown: true }, function () { }));
+
+// once()
+
+expect.type<Podium>(podium.once('test', function () { this instanceof Podium; }));
+expect.type<Podium>(podium.once('test', function () { this.ok; }, { ok: true }));
+expect.type<Podium>(podium.once({ name: 'test' }, function () { }));
+expect.type<Podium>(podium.once({ name: 'test', channels: 'a' }, function () { }));
+expect.type<Podium>(podium.once({ name: 'test', filter: 'a' }, function () { }));
+expect.type<Podium>(podium.once({ name: 'test', filter: { all: true, tags: ['a', 'b'] } }, function () { }));
+expect.type<Podium>(podium.once({ name: 'test', tags: true }, function () { }));
+expect.type<Podium>(podium.once({ name: 'test', clone: true }, function () { }));
+expect.type<Podium>(podium.once({ name: 'test', spread: true }, function () { }));
+expect.type<Promise<any[]>>(podium.once('test'));
+expect.type<Promise<any[]>>(podium.once<void>('test'));
+
+expect.error(podium.once());
+expect.error(podium.once(123, function () { }));
+expect.error(podium.once('test', Podium));
+expect.error(podium.once('test', function () { this.notOk; }, { ok: true }));
+expect.error(podium.once({ name: 'test', unknown: true }, function () { }));
+expect.error(podium.once({ name: 'test', count: 3 }, function () { }));
+
+// removeListener()
+
+expect.type<Podium>(podium.removeListener('test', function () { }));
+
+expect.error(podium.removeListener());
+expect.error(podium.removeListener('test'));
+expect.error(podium.removeListener('test', Podium));
+expect.error(podium.removeListener(123, function () { }));
+
+// removeAllListeners()
+
+expect.type<Podium>(podium.removeAllListeners('test'));
+
+expect.error(podium.removeAllListeners());
+expect.error(podium.removeAllListeners(123));
+expect.error(podium.removeAllListeners('test', function () { }));
+
+// hasListeners()
+
+expect.type<boolean>(podium.hasListeners('test'));
+
+expect.error(podium.hasListeners());
+expect.error(podium.hasListeners(123));


### PR DESCRIPTION
I somehow ended up spending time on an initial pass at some official typescript types…

This is more correct than the [`@types/hapi__podium`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/hapi__podium/index.d.ts) types, which still had references to callbacks, and didn't have types for `await podium.once(event)`. I also applied a bit of _generic + inferred types_ magic to pass the `context` object to the listener.

Feel free to edit any of the embedded docs.

FYI, I omitted the `await podium.few()` method, since it is not documented.