### PR TITLE
Clone the data array before using it as args

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -209,7 +209,7 @@ exports = module.exports = internals.Podium = class {
                 }
 
                 const update = internals.flag('clone', handler, event) ? Hoek.clone(data) : data;
-                const args = internals.flag('spread', handler, event) && Array.isArray(update) ? update : [update];
+                const args = internals.flag('spread', handler, event) && Array.isArray(update) ? update.slice(0) : [update];
 
                 if (internals.flag('tags', handler, event) &&
                     criteria.tags) {

--- a/test/index.js
+++ b/test/index.js
@@ -352,9 +352,27 @@ describe('Podium', () => {
         it('adds tags (spread)', () => {
 
             const emitter = new Podium({ name: 'test', tags: true, spread: true });
-            emitter.on('test', (a, b, c, tags) => {
+            emitter.on('test', (a, b, c, tags, ...rest) => {
 
                 expect({ a, b, c, tags }).to.equal({ a: 1, b: 2, c: 3, tags: { a: true, b: true } });
+                expect(rest).to.have.length(0);
+            });
+
+            emitter.emit({ name: 'test', tags: ['a', 'b'] }, [1, 2, 3]);
+        });
+
+        it('adds tags for multiple listeners (spread)', () => {
+
+            const emitter = new Podium({ name: 'test', tags: true, spread: true });
+            emitter.on('test', (a, b, c, tags, ...rest) => {
+
+                expect({ a, b, c, tags }).to.equal({ a: 1, b: 2, c: 3, tags: { a: true, b: true } });
+                expect(rest).to.have.length(0);
+            });
+            emitter.on('test', (a, b, c, tags, ...rest) => {
+
+                expect({ a, b, c, tags }).to.equal({ a: 1, b: 2, c: 3, tags: { a: true, b: true } });
+                expect(rest).to.have.length(0);
             });
 
             emitter.emit({ name: 'test', tags: ['a', 'b'] }, [1, 2, 3]);


### PR DESCRIPTION
Fixes an invalid behavior when an event is emitted with spread and several handlers, adding tags for each turn.

Since podium is a critical piece, I'm wondering if I should:
- keep it simple like that and always slice
- only slice if tags are to be added

Thoughts?