### PR TITLE
Prepare a breaking build

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -12,15 +12,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        node: ['*', '14', '12']
+        node: ['*', '16', '14']
 
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} node@${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          check-latest: ${{ matrix.node == '*' }}
       - name: install
         run: npm install
       - name: test

--- a/API.md
+++ b/API.md
@@ -365,17 +365,7 @@ event activities. The `events` argument can be:
       registration is ignored. **Note that if the registration config is changed between registrations,
       only the first configuration is used. Defaults to `false` (a duplicate registration will throw an
       error).** For detailed examples of event parameters [see here](README.md#parameters)
-- a `Podium` object which is passed to [`podium.registerPodium()`](#podiumregisterpodiumpodiums).
 - an array containing any of the above.
-
-## `podium.registerPodium(podiums)`
-
-Registers another emitter as an event source for the current emitter (any event update emitted by the
-source emitter is passed to any subscriber of the current emitter) where:
-- `podiums` - a `Podium` object or an array of objects, each added as a source.
-
-Note that any events registered with a source emitter are automatically added to the current emitter.
-If the events are already registered, they are left as-is.
 
 ## `podium.emit(criteria, data)`
 

--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@ is largely insignificant as implementing these features will have similar cost o
 ```js
 const Podium = require('@hapi/podium');
 
-const emitter = new Podium()
+const emitter = new Podium.Podium()
 
 const context = { count: 0 }
 
@@ -86,7 +86,7 @@ Along with channels, podium allows you to specify other event parameters. Below 
 
 ```js
 const Podium = require('@hapi/podium');
-const podiumObject = new Podium();
+const podiumObject = new Podium.Podium();
 
 podiumObject.registerEvent([
     {
@@ -135,7 +135,7 @@ podiumObject.emit({
 
 ```js
 const Podium = require('@hapi/podium');
-const podiumObject = new Podium();
+const podiumObject = new Podium.Podium();
 
 podiumObject.registerEvent([
     {
@@ -193,7 +193,7 @@ console.log('after event2, ch1: ', arr);
 
 ```js
 const Podium = require('@hapi/podium');
-const podiumObject = new Podium();
+const podiumObject = new Podium.Podium();
 
 podiumObject.registerEvent([
     {
@@ -250,7 +250,7 @@ console.log('after event2, ch1: ', arr);
 
 ```js
 const Podium = require('@hapi/podium');
-const podiumObject = new Podium();
+const podiumObject = new Podium.Podium();
 
 podiumObject.registerEvent([
     {
@@ -287,7 +287,7 @@ podiumObject.emit({
 
 ```js
 const Podium = require('@hapi/podium');
-const emitter = new Podium('test');
+const emitter = new Podium.Podium('test');
 
 const updates = [];
 emitter.on('test', (data) => updates.push({ id: 1, data }));

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,11 +23,8 @@ declare class Podium {
 
      * @param criteria - The event update criteria.
      * @param data - The value emitted to the subscribers.
-     * 
-     * @returns Promise that resolves when all events has been processed. Any errors will cause an
-     * immediate rejection.
      */
-    emit(criteria: string | Podium.EmitCriteria, data?: any): Promise<void>;
+    emit(criteria: string | Podium.EmitCriteria, data?: any): void;
 
     /**
      * Subscribe a handler to an event.
@@ -188,7 +185,7 @@ declare namespace Podium {
     type Event = string | EventOptions;
 
     type Listener<TContext extends object = any, TArgs extends any[] = any[]> =
-        (this: TContext, ...args: TArgs) => void | Promise<void>;
+        (this: TContext, ...args: TArgs) => unknown;
 
     interface CriteriaFilterOptionsObject {
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * Node (semi) compatible event emitter with extra features.
  */
-declare class Podium {
+export class Podium {
     /**
      * Creates a new podium emitter.
      * 
@@ -260,5 +260,3 @@ declare namespace Podium {
         readonly tags?: boolean;
     }
 }
-
-export = Podium;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,17 +19,6 @@ declare class Podium {
     registerEvent(events: Podium.Event | Podium.Event[]): void;
 
     /**
-     * Registers another emitter as an event source for the current emitter (any event update
-     * emitted by the source emitter is passed to any subscriber of the current emitter).
-     * 
-     * Note that any events registered with a source emitter are automatically added to the current
-     * emitter. If the events are already registered, they are left as-is.
-     * 
-     * @param podiums - A Podium object or an array of objects, each added as a source.
-     */
-    registerPodium(podiums: Podium | Podium[]): void;
-
-    /**
      * Emits an event update to all the subscribed listeners.
 
      * @param criteria - The event update criteria.
@@ -196,7 +185,7 @@ declare namespace Podium {
         readonly shared?: boolean;
     }
 
-    type Event = string | EventOptions | Podium;
+    type Event = string | EventOptions;
 
     type Listener<TContext extends object = any, TArgs extends any[] = any[]> =
         (this: TContext, ...args: TArgs) => void | Promise<void>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,19 +34,6 @@ internals.schema.listener = internals.schema.event.keys({
 });
 
 
-exports.decorate = function (target, source) {
-
-    exports.Podium.constructor.call(target);
-
-    for (const name of source._eventListeners.keys()) {
-        target._eventListeners.set(name, {
-            handlers: null,
-            flags: source._eventListeners.get(name).flags
-        });
-    }
-};
-
-
 exports.validate = function (events) {
 
     const normalized = [];
@@ -65,20 +52,26 @@ exports.validate = function (events) {
 
 exports.Podium = class {
 
+    static decorate(target, source) {
+
+        for (const [name, entry] of source.#listeners.entries()) {
+            target.#listeners.set(name, {
+                handlers: null,
+                flags: entry.flags
+            });
+        }
+    }
+
+    #listeners = new Map();
+
     constructor(events, options) {
-
-        // Use descriptive names to avoid conflict when inherited
-
-        this._eventListeners = new Map();
-        this._notificationsQueue = [];
-        this._eventsProcessing = false;
 
         if (events) {
             this.registerEvent(events, options);
         }
     }
 
-    registerEvent(events, options = {}) {
+    registerEvent(events, options) {
 
         events = [].concat(events);
         for (let event of events) {
@@ -86,28 +79,28 @@ exports.Podium = class {
                 event = { name: event };
             }
 
-            if (options.validate !== false) {                                                       // Defaults to true
+            if (options?.validate !== false) {                                                       // Defaults to true
                 event = Validate.attempt(event, internals.schema.event, 'Invalid event options');
             }
 
             const name = event.name;
-            if (this._eventListeners.has(name)) {
+            if (this.#listeners.has(name)) {
                 Hoek.assert(event.shared, `Event ${name} exists`);
                 continue;
             }
 
-            this._eventListeners.set(name, { handlers: null, flags: event });
+            this.#listeners.set(name, { handlers: null, flags: event });
         }
     }
 
-    emit(criteria, data, _generated) {
+    emit(criteria, data) {
 
         criteria = internals.criteria(criteria);
 
         const name = criteria.name;
         Hoek.assert(name, 'Criteria missing event name');
 
-        const event = this._eventListeners.get(name);
+        const event = this.#listeners.get(name);
         Hoek.assert(event, `Unknown event ${name}`);
 
         if (!event.handlers) {
@@ -119,7 +112,7 @@ exports.Podium = class {
         Hoek.assert(!event.flags.spread || Array.isArray(data) || typeof data === 'function', 'Data must be an array for spread event');
 
         if (typeof criteria.tags === 'string') {
-            Object.assign({}, criteria);
+            criteria = { ...criteria };
             criteria.tags = { [criteria.tags]: true };
         }
 
@@ -133,10 +126,11 @@ exports.Podium = class {
                 tags[tag] = true;
             }
 
-            Object.assign({}, criteria);
+            criteria = { ...criteria };
             criteria.tags = tags;
         }
 
+        let generated = false;
         let thrownErr;
 
         const handlers = event.handlers.slice();                // Clone in case handlers are changed by listeners
@@ -163,15 +157,15 @@ exports.Podium = class {
             if (handler.count) {
                 --handler.count;
                 if (handler.count < 1) {
-                    internals.removeHandler(this, criteria.name, handler);
+                    this.#removeHandler(criteria.name, handler);
                 }
             }
 
-            if (!_generated &&
+            if (!generated &&
                 typeof data === 'function') {
 
                 data = data();
-                _generated = true;
+                generated = true;
             }
 
             const update = internals.flag('clone', handler, event) ? Hoek.clone(data) : data;
@@ -194,7 +188,7 @@ exports.Podium = class {
                 }
             }
             catch (err) {
-                thrownErr = thrownErr || err;
+                thrownErr = thrownErr ?? err;
             }
         }
 
@@ -203,47 +197,49 @@ exports.Podium = class {
         }
     }
 
-    on(criteria, listener, context) {
+    addListener(criteria, listener, context) {
 
-        criteria = Object.assign({}, internals.criteria(criteria));
+        criteria = internals.criteria(criteria);
         criteria.listener = listener;
         criteria.context = context;
 
         if (criteria.filter &&
             (typeof criteria.filter === 'string' || Array.isArray(criteria.filter))) {
 
+            criteria = { ...criteria };
             criteria.filter = { tags: criteria.filter };
         }
 
         criteria = Validate.attempt(criteria, internals.schema.listener, 'Invalid event listener options');
 
         const name = criteria.name;
-        const event = this._eventListeners.get(name);
+        const event = this.#listeners.get(name);
         Hoek.assert(event, `Unknown event ${name}`);
         Hoek.assert(!criteria.channels || !event.flags.channels || Hoek.intersect(event.flags.channels, criteria.channels).length === criteria.channels.length, `Unknown event channels ${criteria.channels && criteria.channels.join(', ')}`);
 
-        event.handlers = event.handlers || [];
+        event.handlers = event.handlers ?? [];
         event.handlers.push(criteria);
 
         return this;
     }
 
-    addListener(criteria, listener, context) {
+    on(criteria, listener, context) {
 
-        return this.on(criteria, listener, context);
+        return this.addListener(criteria, listener, context);
     }
 
     once(criteria, listener, context) {
 
-        criteria = Object.assign({}, internals.criteria(criteria), { count: 1 });
+        criteria = { ...internals.criteria(criteria), count: 1 };
 
         if (listener) {
-            return this.on(criteria, listener, context);
+            return this.addListener(criteria, listener, context);
         }
 
-        const team = new Teamwork.Team();
-        this.on(criteria, (...args) => team.attend(args));
-        return team.work;
+        return new Promise((resolve) => {
+
+            this.addListener(criteria, (...args) => resolve(args));
+        });
     }
 
     few(criteria, context) {
@@ -252,16 +248,16 @@ exports.Podium = class {
         Hoek.assert(criteria.count, 'Criteria must include a count limit');
 
         const team = new Teamwork.Team({ meetings: criteria.count });
-        this.on(criteria, (...args) => team.attend(args), context);
+        this.addListener(criteria, (...args) => team.attend(args), context);
         return team.work;
     }
 
     removeListener(name, listener) {
 
-        Hoek.assert(this._eventListeners.has(name), `Unknown event ${name}`);
+        Hoek.assert(this.#listeners.has(name), `Unknown event ${name}`);
         Hoek.assert(typeof listener === 'function', 'Listener must be a function');
 
-        const event = this._eventListeners.get(name);
+        const event = this.#listeners.get(name);
         const handlers = event.handlers;
         if (!handlers) {
             return this;
@@ -274,26 +270,28 @@ exports.Podium = class {
 
     removeAllListeners(name) {
 
-        Hoek.assert(this._eventListeners.has(name), `Unknown event ${name}`);
-        this._eventListeners.get(name).handlers = null;
+        Hoek.assert(this.#listeners.has(name), `Unknown event ${name}`);
+        this.#listeners.get(name).handlers = null;
         return this;
     }
 
     hasListeners(name) {
 
-        Hoek.assert(this._eventListeners.has(name), `Unknown event ${name}`);
-        return !!this._eventListeners.get(name).handlers;
+        Hoek.assert(this.#listeners.has(name), `Unknown event ${name}`);
+        return !!this.#listeners.get(name).handlers;
+    }
+
+    #removeHandler(name, handler) {
+
+        const event = this.#listeners.get(name);
+        const handlers = event.handlers;
+        const filtered = handlers.filter((item) => item !== handler);
+        event.handlers = filtered.length ? filtered : null;
     }
 };
 
 
-internals.removeHandler = function (emitter, name, handler) {
-
-    const event = emitter._eventListeners.get(name);
-    const handlers = event.handlers;
-    const filtered = handlers.filter((item) => item !== handler);
-    event.handlers = filtered.length ? filtered : null;
-};
+exports.decorate = exports.Podium.decorate;
 
 
 internals.criteria = function (criteria) {
@@ -308,5 +306,5 @@ internals.criteria = function (criteria) {
 
 internals.flag = function (name, handler, event) {
 
-    return (handler[name] !== undefined ? handler[name] : event.flags[name]) || false;
+    return handler[name] ?? event.flags[name] ?? false;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,16 +52,6 @@ exports.validate = function (events) {
 
 exports.Podium = class {
 
-    static decorate(target, source) {
-
-        for (const [name, entry] of source.#listeners.entries()) {
-            target.#listeners.set(name, {
-                handlers: null,
-                flags: entry.flags
-            });
-        }
-    }
-
     #listeners = new Map();
 
     constructor(events, options) {
@@ -289,9 +279,6 @@ exports.Podium = class {
         event.handlers = filtered.length ? filtered : null;
     }
 };
-
-
-exports.decorate = exports.Podium.decorate;
 
 
 internals.criteria = function (criteria) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ internals.schema.event = internals.schema.base.keys({
 });
 
 
-internals.schema.listener = internals.schema.event.keys({
+internals.schema.listener = internals.schema.base.keys({
     listener: Validate.func().required(),
     context: Validate.object(),
     count: Validate.number().integer().min(1),

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,6 @@ exports = module.exports = internals.Podium = class {
         this._eventListeners = new Map();
         this._notificationsQueue = [];
         this._eventsProcessing = false;
-        this._sourcePodiums = [];
 
         if (events) {
             this.registerEvent(events, options);
@@ -79,17 +78,8 @@ exports = module.exports = internals.Podium = class {
 
     registerEvent(events, options = {}) {
 
-        events = Hoek.flatten([].concat(events));
+        events = [].concat(events);
         for (let event of events) {
-            if (!event) {
-                continue;
-            }
-
-            if (event instanceof internals.Podium) {
-                this.registerPodium(event);
-                continue;
-            }
-
             if (typeof event === 'string') {
                 event = { name: event };
             }
@@ -105,29 +95,6 @@ exports = module.exports = internals.Podium = class {
             }
 
             this._eventListeners.set(name, { handlers: null, flags: event });
-            for (const podium of this._sourcePodiums) {
-                if (!podium._eventListeners.has(name)) {
-                    podium._eventListeners.set(name, { handlers: null, flags: event });
-                }
-            }
-        }
-    }
-
-    registerPodium(podiums) {
-
-        podiums = [].concat(podiums);
-
-        for (const podium of podiums) {
-            if (podium._sourcePodiums.indexOf(this) !== -1) {
-                continue;
-            }
-
-            podium._sourcePodiums.push(this);
-            for (const name of podium._eventListeners.keys()) {
-                if (!this._eventListeners.has(name)) {
-                    this._eventListeners.set(name, { handlers: null, flags: podium._eventListeners.get(name).flags });
-                }
-            }
         }
     }
 
@@ -141,9 +108,7 @@ exports = module.exports = internals.Podium = class {
         const event = this._eventListeners.get(name);
         Hoek.assert(event, `Unknown event ${name}`);
 
-        if (!event.handlers &&
-            !this._sourcePodiums.length) {
-
+        if (!event.handlers) {
             return;
         }
 
@@ -170,74 +135,67 @@ exports = module.exports = internals.Podium = class {
             criteria.tags = tags;
         }
 
-        if (event.handlers) {
-            const processing = [];
+        const processing = [];
 
-            const handlers = event.handlers.slice();                // Clone in case handlers are changed by listeners
-            for (const handler of handlers) {
-                if (handler.channels &&
-                    (!criteria.channel || handler.channels.indexOf(criteria.channel) === -1)) {
+        const handlers = event.handlers.slice();                // Clone in case handlers are changed by listeners
+        for (const handler of handlers) {
+            if (handler.channels &&
+                (!criteria.channel || handler.channels.indexOf(criteria.channel) === -1)) {
 
+                continue;
+            }
+
+            if (handler.filter) {
+                if (!criteria.tags) {
                     continue;
                 }
 
-                if (handler.filter) {
-                    if (!criteria.tags) {
-                        continue;
-                    }
+                const match = Hoek.intersect(criteria.tags, handler.filter.tags, { first: !handler.filter.all });
+                if (!match ||
+                    handler.filter.all && match.length !== handler.filter.tags.length) {
 
-                    const match = Hoek.intersect(criteria.tags, handler.filter.tags, { first: !handler.filter.all });
-                    if (!match ||
-                        handler.filter.all && match.length !== handler.filter.tags.length) {
-
-                        continue;
-                    }
-                }
-
-                if (handler.count) {
-                    --handler.count;
-                    if (handler.count < 1) {
-                        internals.removeHandler(this, criteria.name, handler);
-                    }
-                }
-
-                if (!_generated &&
-                    typeof data === 'function') {
-
-                    data = data();
-                    _generated = true;
-                }
-
-                const update = internals.flag('clone', handler, event) ? Hoek.clone(data) : data;
-                const args = internals.flag('spread', handler, event) && Array.isArray(update) ? update.slice(0) : [update];
-
-                if (internals.flag('tags', handler, event) &&
-                    criteria.tags) {
-
-                    args.push(criteria.tags);
-                }
-
-                try {
-                    const result = handler.context ? handler.listener.apply(handler.context, args) : handler.listener(...args);
-                    if (result &&
-                        typeof result.then === 'function') {
-
-                        processing.push(result);
-                    }
-                }
-                catch (err) {
-                    processing.push(Promise.reject(err));
+                    continue;
                 }
             }
 
-            if (processing.length) {
-                await Promise.all(processing);
+            if (handler.count) {
+                --handler.count;
+                if (handler.count < 1) {
+                    internals.removeHandler(this, criteria.name, handler);
+                }
+            }
+
+            if (!_generated &&
+                typeof data === 'function') {
+
+                data = data();
+                _generated = true;
+            }
+
+            const update = internals.flag('clone', handler, event) ? Hoek.clone(data) : data;
+            const args = internals.flag('spread', handler, event) && Array.isArray(update) ? update.slice(0) : [update];
+
+            if (internals.flag('tags', handler, event) &&
+                criteria.tags) {
+
+                args.push(criteria.tags);
+            }
+
+            try {
+                const result = handler.context ? handler.listener.apply(handler.context, args) : handler.listener(...args);
+                if (result &&
+                    typeof result.then === 'function') {
+
+                    processing.push(result);
+                }
+            }
+            catch (err) {
+                processing.push(Promise.reject(err));
             }
         }
 
-        if (this._sourcePodiums.length) {
-            const podiums = this._sourcePodiums.slice();         // Clone in case modified while processing
-            await Promise.all(podiums.map((podium) => podium.emit(criteria, data, _generated)));
+        if (processing.length) {
+            await Promise.all(processing);
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ exports = module.exports = internals.Podium = class {
         }
     }
 
-    async emit(criteria, data, _generated) {
+    emit(criteria, data, _generated) {
 
         criteria = internals.criteria(criteria);
 
@@ -135,7 +135,7 @@ exports = module.exports = internals.Podium = class {
             criteria.tags = tags;
         }
 
-        const processing = [];
+        let thrownErr;
 
         const handlers = event.handlers.slice();                // Clone in case handlers are changed by listeners
         for (const handler of handlers) {
@@ -181,21 +181,23 @@ exports = module.exports = internals.Podium = class {
                 args.push(criteria.tags);
             }
 
-            try {
-                const result = handler.context ? handler.listener.apply(handler.context, args) : handler.listener(...args);
-                if (result &&
-                    typeof result.then === 'function') {
+            // Call the listener
 
-                    processing.push(result);
+            try {
+                if (handler.context) {
+                    handler.listener.apply(handler.context, args);
+                }
+                else {
+                    handler.listener(...args);
                 }
             }
             catch (err) {
-                processing.push(Promise.reject(err));
+                thrownErr = thrownErr || err;
             }
         }
 
-        if (processing.length) {
-            await Promise.all(processing);
+        if (thrownErr) {
+            throw thrownErr;
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,36 @@ internals.schema.listener = internals.schema.event.keys({
 });
 
 
-exports = module.exports = internals.Podium = class {
+exports.decorate = function (target, source) {
+
+    exports.Podium.constructor.call(target);
+
+    for (const name of source._eventListeners.keys()) {
+        target._eventListeners.set(name, {
+            handlers: null,
+            flags: source._eventListeners.get(name).flags
+        });
+    }
+};
+
+
+exports.validate = function (events) {
+
+    const normalized = [];
+    events = [].concat(events);
+    for (let event of events) {
+        if (typeof event === 'string') {
+            event = { name: event };
+        }
+
+        normalized.push(Validate.attempt(event, internals.schema.event, 'Invalid event options'));
+    }
+
+    return normalized;
+};
+
+
+exports.Podium = class {
 
     constructor(events, options) {
 
@@ -47,33 +76,6 @@ exports = module.exports = internals.Podium = class {
         if (events) {
             this.registerEvent(events, options);
         }
-    }
-
-    static decorate(target, source) {
-
-        internals.Podium.constructor.call(target);
-
-        for (const name of source._eventListeners.keys()) {
-            target._eventListeners.set(name, {
-                handlers: null,
-                flags: source._eventListeners.get(name).flags
-            });
-        }
-    }
-
-    static validate(events) {
-
-        const normalized = [];
-        events = [].concat(events);
-        for (let event of events) {
-            if (typeof event === 'string') {
-                event = { name: event };
-            }
-
-            normalized.push(Validate.attempt(event, internals.schema.event, 'Invalid event options'));
-        }
-
-        return normalized;
     }
 
     registerEvent(events, options = {}) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,7 @@ exports.validate = function (events) {
 
 exports.Podium = class {
 
+    /** @type {Map<string,internals.EventListener>} */
     #listeners = new Map();
 
     constructor(events, options) {
@@ -79,7 +80,7 @@ exports.Podium = class {
                 continue;
             }
 
-            this.#listeners.set(name, { handlers: null, flags: event });
+            this.#listeners.set(name, new internals.EventListener(event));
         }
     }
 
@@ -123,8 +124,7 @@ exports.Podium = class {
         let generated = false;
         let thrownErr;
 
-        const handlers = event.handlers.slice();                // Clone in case handlers are changed by listeners
-        for (const handler of handlers) {
+        for (const handler of event.handlers) {
             if (handler.channels &&
                 !(criteria.channel && handler.channels.has(criteria.channel))) {
 
@@ -144,10 +144,12 @@ exports.Podium = class {
                 }
             }
 
+            // Found a listener, now prepare to call it
+
             if (handler.count) {
                 --handler.count;
                 if (handler.count < 1) {
-                    this.#removeHandler(criteria.name, handler);
+                    event.removeListener(handler.listener);
                 }
             }
 
@@ -158,10 +160,10 @@ exports.Podium = class {
                 generated = true;
             }
 
-            const update = internals.flag('clone', handler, event) ? Hoek.clone(data) : data;
-            const args = internals.flag('spread', handler, event) && Array.isArray(update) ? update.slice(0) : [update];
+            const update = event.flagged('clone', handler) ? Hoek.clone(data) : data;
+            const args = event.flagged('spread', handler) && Array.isArray(update) ? update.slice(0) : [update];
 
-            if (internals.flag('tags', handler, event) &&
+            if (event.flagged('tags', handler) &&
                 criteria.tags) {
 
                 args.push(criteria.tags);
@@ -205,10 +207,8 @@ exports.Podium = class {
         const name = criteria.name;
         const event = this.#listeners.get(name);
         Hoek.assert(event, `Unknown event ${name}`);
-        Hoek.assert(!criteria.channels || !event.flags.channels || Hoek.intersect(event.flags.channels, criteria.channels).length === criteria.channels.size, `Unknown event channels ${criteria.channels && [...criteria.channels].join(', ')}`);
 
-        event.handlers = event.handlers ?? [];
-        event.handlers.push(criteria);
+        event.addHandler(criteria);
 
         return this;
     }
@@ -247,14 +247,7 @@ exports.Podium = class {
         Hoek.assert(this.#listeners.has(name), `Unknown event ${name}`);
         Hoek.assert(typeof listener === 'function', 'Listener must be a function');
 
-        const event = this.#listeners.get(name);
-        const handlers = event.handlers;
-        if (!handlers) {
-            return this;
-        }
-
-        const filtered = handlers.filter((handler) => handler.listener !== listener);
-        event.handlers = filtered.length ? filtered : null;
+        this.#listeners.get(name).removeListener(listener);
         return this;
     }
 
@@ -270,13 +263,33 @@ exports.Podium = class {
         Hoek.assert(this.#listeners.has(name), `Unknown event ${name}`);
         return !!this.#listeners.get(name).handlers;
     }
+};
 
-    #removeHandler(name, handler) {
 
-        const event = this.#listeners.get(name);
-        const handlers = event.handlers;
-        const filtered = handlers.filter((item) => item !== handler);
-        event.handlers = filtered.length ? filtered : null;
+internals.EventListener = class {
+
+    constructor(flags) {
+
+        this.flags = flags;
+        this.handlers = null;
+    }
+
+    addHandler(handler) {
+
+        Hoek.assert(!handler.channels || !this.flags.channels || Hoek.intersect(this.flags.channels, handler.channels).length === handler.channels.size, `Unknown event channels ${handler.channels && [...handler.channels].join(', ')}`);
+
+        this.handlers = this.handlers ? [...this.handlers, handler] : [handler];     // Don't mutate
+    }
+
+    removeListener(listener) {
+
+        const filtered = this.handlers?.filter((item) => item.listener !== listener);
+        this.handlers = filtered?.length ? filtered : null;
+    }
+
+    flagged(name, handler) {
+
+        return handler[name] ?? this.flags[name] ?? false;
     }
 };
 
@@ -288,10 +301,4 @@ internals.criteria = function (criteria) {
     }
 
     return criteria;
-};
-
-
-internals.flag = function (name, handler, event) {
-
-    return handler[name] ?? event.flags[name] ?? false;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const internals = {
             clone: Validate.boolean(),
             tags: Validate.boolean(),
             spread: Validate.boolean(),
-            channels: Validate.array().items(Validate.string()).single().unique().min(1)
+            channels: Validate.array().items(Validate.string()).single().unique().min(1).cast('set')
         })
     }
 };
@@ -98,7 +98,7 @@ exports.Podium = class {
         }
 
         Hoek.assert(!criteria.channel || typeof criteria.channel === 'string', 'Invalid channel name');
-        Hoek.assert(!criteria.channel || !event.flags.channels || event.flags.channels.indexOf(criteria.channel) !== -1, `Unknown ${criteria.channel} channel`);
+        Hoek.assert(!criteria.channel || !event.flags.channels || event.flags.channels.has(criteria.channel), `Unknown ${criteria.channel} channel`);
         Hoek.assert(!event.flags.spread || Array.isArray(data) || typeof data === 'function', 'Data must be an array for spread event');
 
         if (typeof criteria.tags === 'string') {
@@ -126,7 +126,7 @@ exports.Podium = class {
         const handlers = event.handlers.slice();                // Clone in case handlers are changed by listeners
         for (const handler of handlers) {
             if (handler.channels &&
-                (!criteria.channel || handler.channels.indexOf(criteria.channel) === -1)) {
+                !(criteria.channel && handler.channels.has(criteria.channel))) {
 
                 continue;
             }
@@ -205,7 +205,7 @@ exports.Podium = class {
         const name = criteria.name;
         const event = this.#listeners.get(name);
         Hoek.assert(event, `Unknown event ${name}`);
-        Hoek.assert(!criteria.channels || !event.flags.channels || Hoek.intersect(event.flags.channels, criteria.channels).length === criteria.channels.length, `Unknown event channels ${criteria.channels && criteria.channels.join(', ')}`);
+        Hoek.assert(!criteria.channels || !event.flags.channels || Hoek.intersect(event.flags.channels, criteria.channels).length === criteria.channels.size, `Unknown event channels ${criteria.channels && [...criteria.channels].join(', ')}`);
 
         event.handlers = event.handlers ?? [];
         event.handlers.push(criteria);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@hapi/code": "8.x.x",
     "@hapi/eslint-plugin": "*",
     "@hapi/lab": "24.x.x",
-    "typescript": "~4.0.3"
+    "typescript": "~4.4.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ describe('Podium', () => {
 
     it('emits events', () => {
 
-        const emitter = new Podium(['a', 'b', 'c', 'd']);
+        const emitter = new Podium.Podium(['a', 'b', 'c', 'd']);
 
         const updates = [];
 
@@ -70,7 +70,7 @@ describe('Podium', () => {
 
     it('can be inherited from', () => {
 
-        class Sensor extends Podium {
+        class Sensor extends Podium.Podium {
 
             constructor(type) {
 
@@ -121,8 +121,8 @@ describe('Podium', () => {
 
         it('reuses podium events to decorate a new one', () => {
 
-            const source = new Podium(['a', 'b']);
-            const Emitter = class extends Podium { };
+            const source = new Podium.Podium(['a', 'b']);
+            const Emitter = class extends Podium.Podium { };
 
             const emitter = new Emitter();
             Podium.decorate(emitter, source);
@@ -155,7 +155,7 @@ describe('Podium', () => {
 
         it('returns callbacks in order added', () => {
 
-            const emitter = new Podium(['a', 'b']);
+            const emitter = new Podium.Podium(['a', 'b']);
 
             const updates = [];
 
@@ -181,7 +181,7 @@ describe('Podium', () => {
 
         it('invokes all handlers subscribed to an event', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             let handled = 0;
             emitter.on('test', () => {
 
@@ -211,7 +211,7 @@ describe('Podium', () => {
                 return { a: 1 };
             };
 
-            const emitter = new Podium({ name: 'test' });
+            const emitter = new Podium.Podium({ name: 'test' });
 
             let received = 0;
             emitter.on({ name: 'test', filter: 'a' }, (data) => {
@@ -243,7 +243,7 @@ describe('Podium', () => {
                 return inner;
             };
 
-            const emitter = new Podium({ name: 'test' });
+            const emitter = new Podium.Podium({ name: 'test' });
 
             let received = 0;
             const handler = (data) => {
@@ -265,7 +265,7 @@ describe('Podium', () => {
 
             const update = { a: 1 };
 
-            const emitter = new Podium({ name: 'test', clone: true });
+            const emitter = new Podium.Podium({ name: 'test', clone: true });
             const once = emitter.once('test');
 
             emitter.emit('test', update);
@@ -277,7 +277,7 @@ describe('Podium', () => {
 
         it('spreads data', () => {
 
-            const emitter = new Podium({ name: 'test', spread: true });
+            const emitter = new Podium.Podium({ name: 'test', spread: true });
             emitter.on('test', (a, b, c) => {
 
                 expect({ a, b, c }).to.equal({ a: 1, b: 2, c: 3 });
@@ -288,7 +288,7 @@ describe('Podium', () => {
 
         it('spreads data (function)', () => {
 
-            const emitter = new Podium({ name: 'test', spread: true });
+            const emitter = new Podium.Podium({ name: 'test', spread: true });
             emitter.on('test', (a, b, c) => {
 
                 expect({ a, b, c }).to.equal({ a: 1, b: 2, c: 3 });
@@ -299,7 +299,7 @@ describe('Podium', () => {
 
         it('overrides spread data on once with promise', async () => {
 
-            const emitter = new Podium({ name: 'test', spread: true });
+            const emitter = new Podium.Podium({ name: 'test', spread: true });
             const once = emitter.once('test');
             emitter.emit('test', [1, 2, 3]);
             expect(await once).to.equal([1, 2, 3]);
@@ -307,7 +307,7 @@ describe('Podium', () => {
 
         it('adds tags', () => {
 
-            const emitter = new Podium({ name: 'test', tags: true });
+            const emitter = new Podium.Podium({ name: 'test', tags: true });
             emitter.on('test', (data, tags) => {
 
                 expect({ data, tags }).to.equal({ data: [1, 2, 3], tags: { a: true, b: true } });
@@ -318,7 +318,7 @@ describe('Podium', () => {
 
         it('adds tags (spread)', () => {
 
-            const emitter = new Podium({ name: 'test', tags: true, spread: true });
+            const emitter = new Podium.Podium({ name: 'test', tags: true, spread: true });
             emitter.on('test', (a, b, c, tags, ...rest) => {
 
                 expect({ a, b, c, tags }).to.equal({ a: 1, b: 2, c: 3, tags: { a: true, b: true } });
@@ -330,7 +330,7 @@ describe('Podium', () => {
 
         it('adds tags for multiple listeners (spread)', () => {
 
-            const emitter = new Podium({ name: 'test', tags: true, spread: true });
+            const emitter = new Podium.Podium({ name: 'test', tags: true, spread: true });
             emitter.on('test', (a, b, c, tags, ...rest) => {
 
                 expect({ a, b, c, tags }).to.equal({ a: 1, b: 2, c: 3, tags: { a: true, b: true } });
@@ -347,7 +347,7 @@ describe('Podium', () => {
 
         it('send no tags on channel with tags enabled', () => {
 
-            const emitter = new Podium({ name: 'test', tags: true });
+            const emitter = new Podium.Podium({ name: 'test', tags: true });
             emitter.on('test', (data, tags) => {
 
                 expect({ data, tags }).to.equal({ data: [1, 2, 3], tags: undefined });
@@ -358,7 +358,7 @@ describe('Podium', () => {
 
         it('errors on unknown channel', () => {
 
-            const emitter = new Podium({ name: 'test', channels: ['a', 'b'] });
+            const emitter = new Podium.Podium({ name: 'test', channels: ['a', 'b'] });
             emitter.on('test', Hoek.ignore);
 
             expect(() => emitter.emit('test')).to.not.throw();
@@ -368,7 +368,7 @@ describe('Podium', () => {
 
         it('rejects when exception thrown in handler', () => {
 
-            const emitter = new Podium(['a', 'b']);
+            const emitter = new Podium.Podium(['a', 'b']);
 
             const updates = [];
             const aHandler = (data) => updates.push('a');
@@ -387,7 +387,7 @@ describe('Podium', () => {
 
         it('rejects when exception thrown in handler but process all handlers', () => {
 
-            const emitter = new Podium(['a', 'b']);
+            const emitter = new Podium.Podium(['a', 'b']);
 
             const updates = [];
             const handler1 = (data) => updates.push(1);
@@ -411,7 +411,7 @@ describe('Podium', () => {
 
         it('invokes a handler on every event', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             let handled = 0;
             emitter.on('test', () => {
 
@@ -426,7 +426,7 @@ describe('Podium', () => {
 
         it('invokes a handler with context', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             const context = { count: 0 };
             const handler = function () {
 
@@ -443,7 +443,7 @@ describe('Podium', () => {
 
         it('filters events using tags', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
 
             const updates = [];
             emitter.on('test', (data) => updates.push({ id: 1, data }));
@@ -478,7 +478,7 @@ describe('Podium', () => {
 
         it('filter events using channels', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
 
             const updates = [];
             emitter.on('test', (data) => updates.push({ id: 1, data }));
@@ -509,7 +509,7 @@ describe('Podium', () => {
 
             const update = { a: 1 };
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             emitter.on({ name: 'test', clone: true }, (data) => {
 
                 expect(data).to.not.shallow.equal(update);
@@ -521,7 +521,7 @@ describe('Podium', () => {
 
         it('disables tags and spread', () => {
 
-            const emitter = new Podium({ name: 'test', tags: true, spread: true });
+            const emitter = new Podium.Podium({ name: 'test', tags: true, spread: true });
 
             const handler = function (data) {
 
@@ -536,7 +536,7 @@ describe('Podium', () => {
 
         it('errors on unknown channel', () => {
 
-            const emitter = new Podium({ name: 'test', channels: ['a', 'b'] });
+            const emitter = new Podium.Podium({ name: 'test', channels: ['a', 'b'] });
             expect(() => emitter.on('test', Hoek.ignore)).to.not.throw();
             expect(() => emitter.on({ name: 'test', channels: 'a' }, Hoek.ignore)).to.not.throw();
             expect(() => emitter.on({ name: 'test', channels: 'c' }, Hoek.ignore)).to.throw('Unknown event channels c');
@@ -548,7 +548,7 @@ describe('Podium', () => {
 
         it('invokes a handler everytime the subscribed event occurs', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             let handled = 0;
             emitter.addListener('test', () => {
 
@@ -566,7 +566,7 @@ describe('Podium', () => {
 
         it('invokes a handler once', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             let counter = 0;
             emitter.once('test', () => ++counter);
             emitter.emit('test');
@@ -577,7 +577,7 @@ describe('Podium', () => {
 
         it('invokes a handler once (promise)', async () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             const once = emitter.once('test');
             emitter.emit('test', 123);
             emitter.emit('test', null);
@@ -587,7 +587,7 @@ describe('Podium', () => {
 
         it('invokes a handler once with options', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             let counter = 0;
             emitter.once({ name: 'test' }, (data) => {
 
@@ -602,7 +602,7 @@ describe('Podium', () => {
 
         it('invokes a handler once for matching channel', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             let counter = 0;
             emitter.once({ name: 'test', channels: 'x' }, () => ++counter);
             emitter.emit({ name: 'test', channel: 'y' });
@@ -613,7 +613,7 @@ describe('Podium', () => {
 
         it('does not change criteria', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             const criteria = { name: 'test' };
             emitter.once(criteria, Hoek.ignore);
             expect(criteria).to.only.contain('name');
@@ -624,7 +624,7 @@ describe('Podium', () => {
 
         it('collects multiple events', async () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             const few = emitter.few({ name: 'test', count: 3 });
             emitter.emit('test', 123);
             emitter.emit('test', 123);
@@ -639,7 +639,7 @@ describe('Podium', () => {
 
         it('deletes a single handler from being subscribed to an event', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             let handled = 0;
             const handler = () => {
 
@@ -659,7 +659,7 @@ describe('Podium', () => {
 
         it('deletes all handlers from being subscribed to an event', () => {
 
-            const emitter = new Podium('test');
+            const emitter = new Podium.Podium('test');
             let handled = 0;
             emitter.on('test', () => {
 
@@ -703,7 +703,7 @@ describe('Podium', () => {
 
         it('ignores existing when shared is true', () => {
 
-            const source = new Podium();
+            const source = new Podium.Podium();
             source.registerEvent('a');
             expect(() => {
 
@@ -713,7 +713,7 @@ describe('Podium', () => {
 
         it('errors on existing event', () => {
 
-            const source = new Podium();
+            const source = new Podium.Podium();
             source.registerEvent('a');
             expect(() => {
 
@@ -723,7 +723,7 @@ describe('Podium', () => {
 
         it('errors on invalid event property', () => {
 
-            const source = new Podium();
+            const source = new Podium.Podium();
             expect(() => {
 
                 source.registerEvent({ name: 'a', unknown: 'x' });
@@ -732,7 +732,7 @@ describe('Podium', () => {
 
         it('ignores invalid event property', () => {
 
-            const source = new Podium();
+            const source = new Podium.Podium();
             expect(() => {
 
                 source.registerEvent({ name: 'a', unknown: 'x' }, { validate: false });

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ const expect = Code.expect;
 
 describe('Podium', () => {
 
-    it('emits events', async () => {
+    it('emits events', () => {
 
         const emitter = new Podium(['a', 'b', 'c', 'd']);
 
@@ -38,21 +38,21 @@ describe('Podium', () => {
         emitter.emit('d', 4);
         emitter.emit('b', 5);
 
-        await emitter.emit('d', 6);
+        emitter.emit('d', 6);
 
         emitter.removeListener('b', handler2);
         emitter.removeListener('a', Hoek.ignore);
         emitter.removeListener('d', Hoek.ignore);
 
-        await emitter.emit('a', 7);
-        await emitter.emit('b', 8);
+        emitter.emit('a', 7);
+        emitter.emit('b', 8);
 
         emitter.removeAllListeners('a');
         emitter.removeAllListeners('d');
 
         expect(emitter.hasListeners('a')).to.be.false();
 
-        await emitter.emit('a', 9);
+        emitter.emit('a', 9);
 
         expect(updates).to.equal([
             { a: 1, id: 1 },
@@ -68,7 +68,7 @@ describe('Podium', () => {
         ]);
     });
 
-    it('can be inherited from', async () => {
+    it('can be inherited from', () => {
 
         class Sensor extends Podium {
 
@@ -113,13 +113,13 @@ describe('Podium', () => {
             expect(gravity).to.equal(7);
         });
 
-        await thermometer.reading(72);
-        await hydrometer.reading(7);
+        thermometer.reading(72);
+        hydrometer.reading(7);
     });
 
     describe('decorate()', () => {
 
-        it('reuses podium events to decorate a new one', async () => {
+        it('reuses podium events to decorate a new one', () => {
 
             const source = new Podium(['a', 'b']);
             const Emitter = class extends Podium { };
@@ -129,9 +129,8 @@ describe('Podium', () => {
 
             const updates = [];
 
-            const aHandler = async (data) => {
+            const aHandler = (data) => {
 
-                await Hoek.wait(50);
                 updates.push({ a: data, id: 1 });
             };
 
@@ -144,25 +143,24 @@ describe('Podium', () => {
 
             emitter.on('b', bHandler);
 
-            await emitter.emit('a', 1);
+            emitter.emit('a', 1);
             updates.push('a done');
 
-            await emitter.emit('b', 1);
+            emitter.emit('b', 1);
             expect(updates).to.equal([{ a: 1, id: 1 }, 'a done', { b: 1, id: 1 }]);
         });
     });
 
     describe('emit()', () => {
 
-        it('returns callbacks in order added', async () => {
+        it('returns callbacks in order added', () => {
 
             const emitter = new Podium(['a', 'b']);
 
             const updates = [];
 
-            const aHandler = async (data) => {
+            const aHandler = (data) => {
 
-                await Hoek.wait(50);
                 updates.push({ a: data, id: 1 });
             };
 
@@ -175,41 +173,13 @@ describe('Podium', () => {
 
             emitter.on('b', bHandler);
 
-            await emitter.emit('a', 1);
+            emitter.emit('a', 1);
             updates.push('a done');
-            await emitter.emit('b', 1);
+            emitter.emit('b', 1);
             expect(updates).to.equal([{ a: 1, id: 1 }, 'a done', { b: 1, id: 1 }]);
         });
 
-        it('removes handlers while notifications pending', async () => {
-
-            const emitter = new Podium(['a', 'b']);
-
-            const updates = [];
-
-            const aHandler = async (data, next) => {
-
-                updates.push({ a: data, id: 1 });
-                await Hoek.wait(50);
-                emitter.removeAllListeners('b');
-            };
-
-            emitter.on({ name: 'a' }, aHandler);
-
-            const bHandler = (data) => {
-
-                updates.push({ b: data, id: 1 });
-            };
-
-            emitter.on('b', bHandler);
-
-            await emitter.emit('a', 1);
-            updates.push('a done');
-            await emitter.emit('b', 1);
-            expect(updates).to.equal([{ a: 1, id: 1 }, 'a done']);
-        });
-
-        it('invokes all handlers subscribed to an event', async () => {
+        it('invokes all handlers subscribed to an event', () => {
 
             const emitter = new Podium('test');
             let handled = 0;
@@ -228,11 +198,11 @@ describe('Podium', () => {
                 handled++;
             });
 
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(handled).to.equal(3);
         });
 
-        it('generates data once when function', async () => {
+        it('generates data once when function', () => {
 
             let count = 0;
             const update = () => {
@@ -257,13 +227,13 @@ describe('Podium', () => {
             });
 
             emitter.emit({ name: 'test', tags: ['a'] }, update);
-            await emitter.emit({ name: 'test', tags: ['b'] }, update);
+            emitter.emit({ name: 'test', tags: ['b'] }, update);
 
             expect(received).to.equal(2);
             expect(count).to.equal(1);
         });
 
-        it('generates function data', async () => {
+        it('generates function data', () => {
 
             const inner = () => 5;
             let count = 0;
@@ -285,7 +255,7 @@ describe('Podium', () => {
             emitter.on('test', handler);
             emitter.on('test', handler);
 
-            await emitter.emit('test', update);
+            emitter.emit('test', update);
 
             expect(count).to.equal(1);
             expect(received).to.equal(2);
@@ -386,17 +356,17 @@ describe('Podium', () => {
             emitter.emit({ name: 'test' }, [1, 2, 3]);
         });
 
-        it('errors on unknown channel', async () => {
+        it('errors on unknown channel', () => {
 
             const emitter = new Podium({ name: 'test', channels: ['a', 'b'] });
             emitter.on('test', Hoek.ignore);
 
-            await expect(emitter.emit('test')).to.not.reject();
-            await expect(emitter.emit({ name: 'test', channel: 'a' })).to.not.reject();
-            await expect(emitter.emit({ name: 'test', channel: 'c' })).to.reject('Unknown c channel');
+            expect(() => emitter.emit('test')).to.not.throw();
+            expect(() => emitter.emit({ name: 'test', channel: 'a' })).to.not.throw();
+            expect(() => emitter.emit({ name: 'test', channel: 'c' })).to.throw('Unknown c channel');
         });
 
-        it('rejects when exception thrown in handler', async () => {
+        it('rejects when exception thrown in handler', () => {
 
             const emitter = new Podium(['a', 'b']);
 
@@ -412,10 +382,10 @@ describe('Podium', () => {
             emitter.on('b', bHandler);
             emitter.emit('a', 1);
 
-            await expect(emitter.emit('b', 1)).to.reject('oops');
+            expect(() => emitter.emit('b', 1)).to.throw('oops');
         });
 
-        it('rejects when exception thrown in handler but process all handlers', async () => {
+        it('rejects when exception thrown in handler but process all handlers', () => {
 
             const emitter = new Podium(['a', 'b']);
 
@@ -432,14 +402,14 @@ describe('Podium', () => {
             emitter.on('a', handler1);
             emitter.on('a', handler2);
             emitter.on('a', handler1);
-            await expect(emitter.emit('a', 1)).to.reject('oops');
+            expect(() => emitter.emit('a', 1)).to.throw('oops');
             expect(updates).to.equal([1, 2, 1, 2, 1]);
         });
     });
 
     describe('on()', () => {
 
-        it('invokes a handler on every event', async () => {
+        it('invokes a handler on every event', () => {
 
             const emitter = new Podium('test');
             let handled = 0;
@@ -450,11 +420,11 @@ describe('Podium', () => {
 
             emitter.emit('test');
             emitter.emit('test');
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(handled).to.equal(3);
         });
 
-        it('invokes a handler with context', async () => {
+        it('invokes a handler with context', () => {
 
             const emitter = new Podium('test');
             const context = { count: 0 };
@@ -467,11 +437,11 @@ describe('Podium', () => {
 
             emitter.emit('test');
             emitter.emit('test');
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(context.count).to.equal(3);
         });
 
-        it('filters events using tags', async () => {
+        it('filters events using tags', () => {
 
             const emitter = new Podium('test');
 
@@ -487,7 +457,7 @@ describe('Podium', () => {
             emitter.emit({ name: 'test', tags: ['d'] }, 3);
             emitter.emit({ name: 'test', tags: ['a'] }, 4);
             emitter.emit({ name: 'test', tags: ['a', 'b'] }, 5);
-            await emitter.emit('test', 6);
+            emitter.emit('test', 6);
 
             expect(updates).to.equal([
                 { id: 1, data: 1 },
@@ -506,7 +476,7 @@ describe('Podium', () => {
             ]);
         });
 
-        it('filter events using channels', async () => {
+        it('filter events using channels', () => {
 
             const emitter = new Podium('test');
 
@@ -520,7 +490,7 @@ describe('Podium', () => {
             emitter.emit({ name: 'test', channel: 'b' }, 2);
             emitter.emit({ name: 'test', channel: 'd' }, 3);
             emitter.emit({ name: 'test', channel: 'a' }, 4);
-            await emitter.emit('test', 6);
+            emitter.emit('test', 6);
 
             expect(updates).to.equal([
                 { id: 1, data: 1 },
@@ -576,7 +546,7 @@ describe('Podium', () => {
 
     describe('addListener()', () => {
 
-        it('invokes a handler everytime the subscribed event occurs', async () => {
+        it('invokes a handler everytime the subscribed event occurs', () => {
 
             const emitter = new Podium('test');
             let handled = 0;
@@ -587,21 +557,21 @@ describe('Podium', () => {
 
             emitter.emit('test');
             emitter.emit('test');
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(handled).to.equal(3);
         });
     });
 
     describe('once()', () => {
 
-        it('invokes a handler once', async () => {
+        it('invokes a handler once', () => {
 
             const emitter = new Podium('test');
             let counter = 0;
             emitter.once('test', () => ++counter);
             emitter.emit('test');
             emitter.emit('test');
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(counter).to.equal(1);
         });
 
@@ -610,12 +580,12 @@ describe('Podium', () => {
             const emitter = new Podium('test');
             const once = emitter.once('test');
             emitter.emit('test', 123);
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             const [result] = await once;
             expect(result).to.equal(123);
         });
 
-        it('invokes a handler once with options', async () => {
+        it('invokes a handler once with options', () => {
 
             const emitter = new Podium('test');
             let counter = 0;
@@ -626,18 +596,18 @@ describe('Podium', () => {
 
             emitter.emit('test');
             emitter.emit('test');
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(counter).to.equal(1);
         });
 
-        it('invokes a handler once for matching channel', async () => {
+        it('invokes a handler once for matching channel', () => {
 
             const emitter = new Podium('test');
             let counter = 0;
             emitter.once({ name: 'test', channels: 'x' }, () => ++counter);
             emitter.emit({ name: 'test', channel: 'y' });
             emitter.emit({ name: 'test', channel: 'x' });
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(counter).to.equal(1);
         });
 
@@ -659,7 +629,7 @@ describe('Podium', () => {
             emitter.emit('test', 123);
             emitter.emit('test', 123);
             emitter.emit('test', 123);
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             const result = await few;
             expect(result).to.equal([[123], [123], [123]]);
         });
@@ -667,7 +637,7 @@ describe('Podium', () => {
 
     describe('removeListener()', () => {
 
-        it('deletes a single handler from being subscribed to an event', async () => {
+        it('deletes a single handler from being subscribed to an event', () => {
 
             const emitter = new Podium('test');
             let handled = 0;
@@ -678,16 +648,16 @@ describe('Podium', () => {
 
             emitter.addListener('test', handler);
 
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             emitter.removeListener('test', handler);
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(handled).to.equal(1);
         });
     });
 
     describe('removeAllListeners()', () => {
 
-        it('deletes all handlers from being subscribed to an event', async () => {
+        it('deletes all handlers from being subscribed to an event', () => {
 
             const emitter = new Podium('test');
             let handled = 0;
@@ -706,9 +676,9 @@ describe('Podium', () => {
                 handled++;
             });
 
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             emitter.removeAllListeners('test');
-            await emitter.emit('test', null);
+            emitter.emit('test', null);
             expect(handled).to.equal(3);
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -117,40 +117,6 @@ describe('Podium', () => {
         hydrometer.reading(7);
     });
 
-    describe('decorate()', () => {
-
-        it('reuses podium events to decorate a new one', () => {
-
-            const source = new Podium.Podium(['a', 'b']);
-            const Emitter = class extends Podium.Podium { };
-
-            const emitter = new Emitter();
-            Podium.decorate(emitter, source);
-
-            const updates = [];
-
-            const aHandler = (data) => {
-
-                updates.push({ a: data, id: 1 });
-            };
-
-            emitter.on({ name: 'a' }, aHandler);
-
-            const bHandler = (data) => {
-
-                updates.push({ b: data, id: 1 });
-            };
-
-            emitter.on('b', bHandler);
-
-            emitter.emit('a', 1);
-            updates.push('a done');
-
-            emitter.emit('b', 1);
-            expect(updates).to.equal([{ a: 1, id: 1 }, 'a done', { b: 1, id: 1 }]);
-        });
-    });
-
     describe('emit()', () => {
 
         it('returns callbacks in order added', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,11 +25,11 @@ expect.error(podium.registerEvent([Symbol()]));
 
 // emit()
 
-expect.type<Promise<void>>(podium.emit('test'));
-expect.type<Promise<void>>(podium.emit('test', { data: true }));
-expect.type<Promise<void>>(podium.emit({ name: 'test', channel: 'a', tags: 'b' }, { data: true }));
-expect.type<Promise<void>>(podium.emit({ name: 'test', tags: ['b'] }));
-expect.type<Promise<void>>(podium.emit({ name: 'test', tags: { b: true } }));
+expect.type<void>(podium.emit('test'));
+expect.type<void>(podium.emit('test', { data: true }));
+expect.type<void>(podium.emit({ name: 'test', channel: 'a', tags: 'b' }, { data: true }));
+expect.type<void>(podium.emit({ name: 'test', tags: ['b'] }));
+expect.type<void>(podium.emit({ name: 'test', tags: { b: true } }));
 
 expect.error(podium.emit());
 expect.error(podium.emit(123));
@@ -72,7 +72,7 @@ expect.error(podium.on('test', function () { this.notOk; }, { ok: true }));
 
 expect.type<Podium>(podium.addListener('test', function () { this instanceof Podium; }));
 expect.type<Podium>(podium.addListener('test', function () { this.ok; }, { ok: true }));
-expect.type<Podium>(podium.addListener('test', function () { this.ok; }, { ok: true }));
+expect.type<Podium>(podium.addListener('test', () => true));
 expect.type<Podium>(podium.addListener<[a: string, b: number], { ok: boolean }>('test', function (a, b) {
 
     expect.type<boolean>(this.ok);

--- a/test/index.ts
+++ b/test/index.ts
@@ -8,27 +8,20 @@ const { expect } = Lab.types;
 
 expect.type<Podium>(new Podium());
 expect.type<Podium>(new Podium('test'));
-expect.type<Podium>(new Podium(['a', { name: 'b', channels: ['c'] }, new Podium()]));
+expect.type<Podium>(new Podium(['a', { name: 'b', channels: ['c'] }]));
+
+expect.error(new Podium(new Podium()));
 
 const podium = new Podium();
 
 // registerEvent()
 
 expect.type<void>(podium.registerEvent('test'));
-expect.type<void>(podium.registerEvent(['a', { name: 'b', channels: ['c'] }, new Podium()]));
-
+expect.type<void>(podium.registerEvent(['a', { name: 'b', channels: ['c'] }]));
 expect.error(podium.registerEvent());
+expect.error(podium.registerEvent(new Podium()));
 expect.error(podium.registerEvent(123));
 expect.error(podium.registerEvent([Symbol()]));
-
-// registerPodium()
-
-expect.type<void>(podium.registerPodium(new Podium()));
-expect.type<void>(podium.registerPodium([new Podium()]));
-
-expect.error(podium.registerPodium());
-expect.error(podium.registerPodium('test'));
-expect.error(podium.registerPodium([{ name: 'test' }]));
 
 // emit()
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,4 +1,4 @@
-import * as Podium from '..';
+import { Podium } from '..';
 import * as Lab from '@hapi/lab';
 
 


### PR DESCRIPTION
Contains two breaking changes that removes functionality (#65 & #73), and two breaking changes for maintenance (#74 & #75).

Note that when I removed promise support from `emit()`, I took care to preserve the behaviour that a handler `throw` will not stop the other handlers from being called. This is different from how node events work, where a `throw` immediately falls up the the caller.

Besides the breaking changes, I also took the opportunity to do some cleaning, which can be seen through the remaining commits. For instance I completely removed `exports.decorate()` which was poorly implemented, not documented, and not used in any hapi projects.

The only outstanding issue before this is ready to be published, is updating any dependencies that are going to have a breaking release for hapijs/hapi#4279. This is pending that they are actually published.

If anyone is up for it, there are some undocumented (and not in ts.d) APIs that would be nice to finally include: The ones I have found are:

 1. `exports.validate()` (used in hapi, catbox & beam)
 2. the `options` argument of `new Podium()` and `podium.registerEvent()`
 3. `podium.once()` called without a `listener` (which then returns a promise).
 4. the `podium.few()` method.

Additionally, I feel that it would be nice to add a `podium.off()` method that aliases `podium.removeListener()`.

Let me know if I should break up the first two commits into separate PRs for easier review (but where should it be merged to?).