### PR TITLE
Support podium.gauge() method

### DIFF
--- a/API.md
+++ b/API.md
@@ -442,11 +442,15 @@ in the object format supported by [`podium.on()`](#podiumoncriteria-listener) an
 
 Returns a promise that resolves when the event is emitted `count` times. The resolution value is an array where each item is an array of emitted arguments.
 
-## `podium.removeListener(name, listener)`
+## `podium.off(name, listener)`
 
 Removes all listeners subscribed to a given event name matching the provided listener method where:
 - `name` - the event name **string**.
 - `listener` - the function reference provided when subscribed.
+
+## `podium.removeListener(name, listener)`
+
+Same as [`podium.off()`](#podiumoffname-listener).
 
 Returns a reference to the current emitter.
 

--- a/API.md
+++ b/API.md
@@ -383,6 +383,13 @@ Emits an event update to all the subscribed listeners where:
         - `tags` - a tag string or array of tag strings.
 - `data` - the value emitted to the subscribers.
 
+## `await podium.gauge(criteria, data)`
+
+Behaves identically to `podium.emit()`, but also returns an array of the results of all the event listeners that run. The return value is that of `Promise.allSettled()`, where each item in the resulting array is `{ status: 'fulfilled', value }` in the case of a successful handler, or `{ status: 'rejected', reason }` in the case of a handler that throws.
+
+Please note that system errors such as a `TypeError` are not handled specially, and it's recommended to scrutinize any rejections using something like [bounce](https://hapi.dev/module/bounce/).
+
+
 ## `podium.on(criteria, listener, context)`
 
 Subscribe a handler to an event where:

--- a/API.md
+++ b/API.md
@@ -350,15 +350,15 @@ event activities. The `events` argument can be:
     - `name` - the event name **string (required)**.
     - `channels` - a **string** or **array of strings** specifying the event channels available. **Defaults
        to no channel restrictions (event updates can specify a channel or not).**
-    - `clone` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
+    - `clone` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data)
         is cloned before it is passed to the listeners (unless an override specified by each listener).
         **Defaults to `false` (`data` is passed as-is).**
-    - `spread` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
+    - `spread` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data)
         **must be an array** and the `listener` method is called with each array element passed as a separate
         argument (unless an override specified by each listener). **This should only be used when the emitted
         data structure is known and predictable.**
         **Defaults to `false` (`data` is emitted as a single argument regardless of its type).**
-    - `tags` - if `true` and the `criteria` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
+    - `tags` - if `true` and the `criteria` object passed to [`podium.emit()`](#podiumemitcriteria-data)
         includes `tags`, the tags are mapped to an object (where each tag string is the key and
         the value is `true`) which is appended to the arguments list at the end. A configuration override can be set by each
         listener. **Defaults to `false`.**
@@ -395,7 +395,7 @@ Subscribe a handler to an event where:
           match the allowed channels. If `channels` are specified, event updates without any
           channel designation will not be included in the subscription. **Defaults to no channels
           filter.**
-        - `clone` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
+        - `clone` - if `true`, the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data)
            is cloned before it is passed to the `listener` method. **Defaults to the event
            registration option (which defaults to `false`).**
         - `count` - a positive **integer** indicating the number of times the `listener` can be called
@@ -408,11 +408,11 @@ Subscribe a handler to an event where:
                 - `tags` - a tag **string** or **array** of tag **strings**.
                 - `all` - if `true`, all `tags` must be present for the event update to match the
                   subscription. **Defaults to `false` (at least one matching tag).**
-        - `spread` - if `true`, and the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
+        - `spread` - if `true`, and the `data` object passed to [`podium.emit()`](#podiumemitcriteria-data)
           is an **array**, the `listener` method is called with each **array element** passed as a separate
           argument. **This should only be used when the emitted data structure is known and predictable.
           Defaults to the event registration option (which defaults to `false`).**
-        - `tags` - if `true` and the `criteria` object passed to [`podium.emit()`](#podiumemitcriteria-data-callback)
+        - `tags` - if `true` and the `criteria` object passed to [`podium.emit()`](#podiumemitcriteria-data)
           includes `tags`, the tags are mapped to an object (where each tag string is the key and
           the value is `true`) which is appended to the arguments list at the end. **Defaults to the event registration option
           (which defaults to `false`).**
@@ -422,23 +422,23 @@ Subscribe a handler to an event where:
 
 ## `podium.addListener(criteria, listener, context)`
 
-Same as [`podium.on()`](#podiumoncriteria-listener).
+Same as [`podium.on()`](#podiumoncriteria-listener-context).
 
 ## `podium.once(criteria, listener, context)`
 
-Same as calling [`podium.on()`](#podiumoncriteria-listener) with the `count` option set to `1`.
+Same as calling [`podium.on()`](#podiumoncriteria-listener-context) with the `count` option set to `1`.
 
 ## `await podium.once(criteria)`
 
 Subscribes to an event by returning a promise that resolves when the event is emitted. `criteria` can be specified
-in any format supported by [`podium.on()`](#podiumoncriteria-listener), except for the `count` option that is set to `1`.
+in any format supported by [`podium.on()`](#podiumoncriteria-listener-context), except for the `count` option that is set to `1`.
 
 Return a promise that resolves when the event is emitted. The resolution value is an array of emitted arguments.
 
 ## `podium.few(criteria)`
 
 Subscribes to an event by returning a promise that resolves when the event is emitted `count` times. `criteria` can only be specified
-in the object format supported by [`podium.on()`](#podiumoncriteria-listener) and the `count` option is required.
+in the object format supported by [`podium.on()`](#podiumoncriteria-listener-context) and the `count` option is required.
 
 Returns a promise that resolves when the event is emitted `count` times. The resolution value is an array where each item is an array of emitted arguments.
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -29,6 +29,14 @@ export class Podium {
     emit(criteria: string | Podium.EmitCriteria, data?: any): void;
 
     /**
+     * Emits an event update to all the subscribed listeners and resolves an array of their results.
+
+     * @param criteria - The event update criteria.
+     * @param data - The value emitted to the subscribers.
+     */
+     gauge<T = unknown>(criteria: string | Podium.EmitCriteria, data?: any): Promise<PromiseSettledResult<T>[]>;
+
+    /**
      * Subscribe a handler to an event.
      *
      * @param criteria - The subscription criteria.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,17 +4,17 @@
 export class Podium {
     /**
      * Creates a new podium emitter.
-     * 
+     *
      * @param events - If present, the value is passed to podium.registerEvent().
      * @param options - optional configuration options passed to podium.registerEvent().
      */
     constructor(events?: Podium.Event | Podium.Event[], options?: Podium.EventSettings);
 
     /**
-     * Register the specified events and their optional configuration. Events must be registered 
+     * Register the specified events and their optional configuration. Events must be registered
      * before they can be emitted or subscribed to. This is done to detect event name mispelling
      * and invalid event activities.
-     * 
+     *
      * @param events - The event(s) to register.
      * @param options - optional configuration options.
      */
@@ -30,7 +30,7 @@ export class Podium {
 
     /**
      * Subscribe a handler to an event.
-     * 
+     *
      * @param criteria - The subscription criteria.
      * @param listener - The handler method set to receive event updates. The function signature
      *                   depends on the block, spread, and tags options.
@@ -56,9 +56,9 @@ export class Podium {
 
     /**
      * Same as podium.on() with the count option set to 1.
-     * 
+     *
      * Can also be called without an listener to wait for a single event.
-     * 
+     *
      * @param criteria - The subscription criteria.
      * @param listener - The handler method set to receive event updates. The function signature
      *                   depends on the block, spread, and tags options.
@@ -71,7 +71,7 @@ export class Podium {
 
     /**
      * Subscribes to an event by returning a promise that resolves when the event is emitted.
-     * 
+     *
      * @param criteria - The subscription criteria.
      *
      * @returns Promise with array of emitted parameters.
@@ -81,7 +81,7 @@ export class Podium {
 
     /**
      * Subscribes to an event by returning a promise that resolves when the event is emitted `count` times.
-     * 
+     *
      * @param criteria - The subscription criteria.
      *
      * @returns Promise with array where each item is an array of emitted arguments.
@@ -91,28 +91,38 @@ export class Podium {
 
     /**
      * Removes all listeners subscribed to a given event name matching the provided listener method.
-     * 
+     *
      * @param name - The event name string.
      * @param listener - The function reference provided when subscribed.
-     * 
+     *
+     * @returns A reference to the current emitter.
+     */
+     off(name: string, listener: Podium.Listener): this;
+
+    /**
+     * Removes all listeners subscribed to a given event name matching the provided listener method.
+     *
+     * @param name - The event name string.
+     * @param listener - The function reference provided when subscribed.
+     *
      * @returns A reference to the current emitter.
      */
     removeListener(name: string, listener: Podium.Listener): this;
 
     /**
      * Removes all listeners subscribed to a given event name.
-     * 
+     *
      * @param name - The event name string.
-     * 
+     *
      * @returns A reference to the current emitter.
      */
     removeAllListeners(name: string): this;
 
     /**
      * Returns whether an event has any listeners subscribed.
-     * 
+     *
      * @param name  the event name string.
-     * 
+     *
      * @returns true if the event name has any listeners, otherwise false.
      */
     hasListeners(name: string): boolean;
@@ -120,7 +130,7 @@ export class Podium {
 
 declare namespace Podium {
 
-    export interface EmitCriteria { 
+    export interface EmitCriteria {
 
         /**
          * Event name.
@@ -147,7 +157,7 @@ declare namespace Podium {
 
         /**
          * A string or array of strings specifying the event channels available.
-         * 
+         *
          * Defaults to no channel restrictions - Event updates can specify a channel or not.
          */
         readonly channels?: string | string[];
@@ -155,7 +165,7 @@ declare namespace Podium {
         /**
          * Set to make podium.emit() clone the data object passed to it, before it is passed to the
          * listeners (unless an override specified by each listener).
-         * 
+         *
          * Defaults to false - Data is passed as-is.
          */
         readonly clone?: boolean;
@@ -164,9 +174,9 @@ declare namespace Podium {
          * Set to require the data object passed to podium.emit() to be an array, and make the
          * listener method called with each array element passed as a separate argument (unless an
          * override specified by each listener).
-         * 
+         *
          * This should only be used when the emitted data structure is known and predictable.
-         * 
+         *
          * Defaults to false - Data is emitted as a single argument regardless of its type.
          */
         readonly spread?: boolean;
@@ -175,9 +185,9 @@ declare namespace Podium {
          * Set to make any tags in the critieria object passed to podium.emit() map to an object
          * (where each tag string is the key and the value is true) which is appended to the emitted
          * arguments list at the end.
-         * 
+         *
          * A configuration override can be set by each listener.
-         * 
+         *
          * Defaults to false.
          */
         readonly tags?: boolean;
@@ -185,10 +195,10 @@ declare namespace Podium {
         /**
          * Set to allow the same event name to be registered multiple times, ignoring all but the
          * first.
-         * 
+         *
          * Note that if the registration config is changed between registrations, only the first
          * configuration is used.
-         * 
+         *
          * Defaults to false - A duplicate registration will throw an error.
          */
         readonly shared?: boolean;
@@ -201,7 +211,7 @@ declare namespace Podium {
         /**
          * If false, events are not validated. This is only allowed when the events
          * value is returned from Podium.validate().
-         * 
+         *
          * Defaults to true
          */
         readonly validate?: boolean;
@@ -219,7 +229,7 @@ declare namespace Podium {
 
         /**
          * Require all tags to be present for the event update to match the subscription.
-         * 
+         *
          * Default false - Require at least one matching tag.
          */
         readonly all?: boolean;
@@ -234,11 +244,11 @@ declare namespace Podium {
 
         /**
          * The event channels to subscribe to.
-         * 
+         *
          * If the event registration specified a list of allowed channels, the channels array must
          * match the allowed channels. If channels are specified, event updates without any channel
          * designation will not be included in the subscription.
-         * 
+         *
          * Defaults to no channels filter.
          */
         readonly channels?: string | string[];
@@ -246,7 +256,7 @@ declare namespace Podium {
         /**
          * Set to clone the data object passed to podium.emit() before it is passed to the listener
          * method.
-         * 
+         *
          * Defaults to the event registration option (which defaults to false).
          */
         readonly clone?: boolean;
@@ -254,9 +264,9 @@ declare namespace Podium {
         /**
          * A positive non-zero integer indicating the number of times the listener can be called
          * after which the subscription is automatically removed.
-         * 
+         *
          * Does nothing when calling once(), where it will use the value 1.
-         * 
+         *
          * Defaults to no limit.
          */
         readonly count?: number;
@@ -268,21 +278,21 @@ declare namespace Podium {
 
         /**
          * Override the value of spread from the event registraiont when the listener is called.
-         * 
+         *
          * This should only be used when the emitted data structure is known and predictable.
-         * 
+         *
          * Defaults to the event registration option (which defaults to false).
          */
         readonly spread?: boolean;
 
         /**
          * Override the value of tags from the event registraiont when the listener is called.
-         * 
+         *
          * Defaults to the event registration option (which defaults to false).
          */
         readonly tags?: boolean;
     }
-    
+
     export interface CriteriaObjectWithCount extends CriteriaObject {
         /**
          * A positive non-zero integer indicating the number of times the listener can be called

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ exports.Podium = class {
 
         let thrownErr;
 
-        this.#emitToEachHandler(criteria, data, ([err]) => {
+        this.#emitToEachListener(criteria, data, ([err]) => {
 
             thrownErr = thrownErr ?? err;
         });
@@ -102,7 +102,7 @@ exports.Podium = class {
 
         const promises = [];
 
-        this.#emitToEachHandler(criteria, data, ([err, result]) => {
+        this.#emitToEachListener(criteria, data, ([err, result]) => {
 
             promises.push(err ? Promise.reject(err) : result);
         });
@@ -110,7 +110,7 @@ exports.Podium = class {
         return await Promise.allSettled(promises);
     }
 
-    #emitToEachHandler(criteria, data, fn) {
+    #emitToEachListener(criteria, data, fn) {
 
         criteria = internals.criteria(criteria);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,6 +86,32 @@ exports.Podium = class {
 
     emit(criteria, data) {
 
+        let thrownErr;
+
+        this.#emitToEachHandler(criteria, data, ([err]) => {
+
+            thrownErr = thrownErr ?? err;
+        });
+
+        if (thrownErr) {
+            throw thrownErr;
+        }
+    }
+
+    async gauge(criteria, data) {
+
+        const promises = [];
+
+        this.#emitToEachHandler(criteria, data, ([err, result]) => {
+
+            promises.push(err ? Promise.reject(err) : result);
+        });
+
+        return await Promise.allSettled(promises);
+    }
+
+    #emitToEachHandler(criteria, data, fn) {
+
         criteria = internals.criteria(criteria);
 
         const name = criteria.name;
@@ -122,7 +148,6 @@ exports.Podium = class {
         }
 
         let generated = false;
-        let thrownErr;
 
         for (const handler of event.handlers) {
             if (handler.channels &&
@@ -173,19 +198,15 @@ exports.Podium = class {
 
             try {
                 if (handler.context) {
-                    handler.listener.apply(handler.context, args);
+                    fn([null, handler.listener.apply(handler.context, args)]);
                 }
                 else {
-                    handler.listener(...args);
+                    fn([null, handler.listener(...args)]);
                 }
             }
             catch (err) {
-                thrownErr = thrownErr ?? err;
+                fn([err, null]);
             }
-        }
-
-        if (thrownErr) {
-            throw thrownErr;
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -251,6 +251,11 @@ exports.Podium = class {
         return this;
     }
 
+    off(name, listener) {
+
+        return this.removeListener(name, listener);
+    }
+
     removeAllListeners(name) {
 
         Hoek.assert(this.#listeners.has(name), `Unknown event ${name}`);

--- a/test/index.js
+++ b/test/index.js
@@ -241,7 +241,7 @@ describe('Podium', () => {
             expect(data).to.equal(update);
         });
 
-        it('spreads data', () => {
+        it('spreads data', { plan: 1 }, () => {
 
             const emitter = new Podium.Podium({ name: 'test', spread: true });
             emitter.on('test', (a, b, c) => {
@@ -252,7 +252,7 @@ describe('Podium', () => {
             emitter.emit('test', [1, 2, 3]);
         });
 
-        it('spreads data (function)', () => {
+        it('spreads data (function)', { plan: 1 }, () => {
 
             const emitter = new Podium.Podium({ name: 'test', spread: true });
             emitter.on('test', (a, b, c) => {
@@ -271,7 +271,7 @@ describe('Podium', () => {
             expect(await once).to.equal([1, 2, 3]);
         });
 
-        it('adds tags', () => {
+        it('adds tags', { plan: 1 }, () => {
 
             const emitter = new Podium.Podium({ name: 'test', tags: true });
             emitter.on('test', (data, tags) => {
@@ -282,7 +282,7 @@ describe('Podium', () => {
             emitter.emit({ name: 'test', tags: ['a', 'b'] }, [1, 2, 3]);
         });
 
-        it('adds tags (spread)', () => {
+        it('adds tags (spread)', { plan: 2 }, () => {
 
             const emitter = new Podium.Podium({ name: 'test', tags: true, spread: true });
             emitter.on('test', (a, b, c, tags, ...rest) => {
@@ -294,7 +294,7 @@ describe('Podium', () => {
             emitter.emit({ name: 'test', tags: ['a', 'b'] }, [1, 2, 3]);
         });
 
-        it('adds tags for multiple listeners (spread)', () => {
+        it('adds tags for multiple listeners (spread)', { plan: 4 }, () => {
 
             const emitter = new Podium.Podium({ name: 'test', tags: true, spread: true });
             emitter.on('test', (a, b, c, tags, ...rest) => {
@@ -311,7 +311,7 @@ describe('Podium', () => {
             emitter.emit({ name: 'test', tags: ['a', 'b'] }, [1, 2, 3]);
         });
 
-        it('send no tags on channel with tags enabled', () => {
+        it('send no tags on channel with tags enabled', { plan: 1 }, () => {
 
             const emitter = new Podium.Podium({ name: 'test', tags: true });
             emitter.on('test', (data, tags) => {
@@ -370,6 +370,259 @@ describe('Podium', () => {
             emitter.on('a', handler1);
             expect(() => emitter.emit('a', 1)).to.throw('oops');
             expect(updates).to.equal([1, 2, 1, 2, 1]);
+        });
+    });
+
+    describe('gauge()', () => {
+
+        it('returns the result of all handlers subscribed to an event in order', async () => {
+
+            const emitter = new Podium.Podium('test');
+
+            emitter.on('test', () => {
+
+                return 'a';
+            });
+
+            emitter.on('test', async () => {
+
+                await Hoek.wait();
+
+                return 'b';
+            });
+
+            emitter.on('test', () => {
+
+                return 'c';
+            });
+
+            const results = await emitter.gauge('test');
+            expect(results).to.equal([
+                { status: 'fulfilled', value: 'a' },
+                { status: 'fulfilled', value: 'b' },
+                { status: 'fulfilled', value: 'c' }
+            ]);
+        });
+
+        it('returns the result of failed handlers', async () => {
+
+            const emitter = new Podium.Podium('test');
+
+            emitter.on('test', () => {
+
+                throw new Error('a');
+            });
+
+            emitter.on('test', async () => {
+
+                await Hoek.wait();
+
+                throw new Error('b');
+            });
+
+            emitter.on('test', () => {
+
+                return 'c';
+            });
+
+            const results = await emitter.gauge('test', 'x');
+            expect(results).to.equal([
+                { status: 'rejected', reason: new Error('a') },
+                { status: 'rejected', reason: new Error('b') },
+                { status: 'fulfilled', value: 'c' }
+            ]);
+        });
+
+        // Tests below are adapted from emit()
+
+        it('returns callbacks in order added', () => {
+
+            const emitter = new Podium.Podium(['a', 'b']);
+
+            const updates = [];
+
+            const aHandler = (data) => {
+
+                updates.push({ a: data, id: 1 });
+            };
+
+            emitter.on({ name: 'a' }, aHandler);
+
+            const bHandler = (data) => {
+
+                updates.push({ b: data, id: 1 });
+            };
+
+            emitter.on('b', bHandler);
+
+            emitter.gauge('a', 1);
+            updates.push('a done');
+            emitter.gauge('b', 1);
+            expect(updates).to.equal([{ a: 1, id: 1 }, 'a done', { b: 1, id: 1 }]);
+        });
+
+        it('generates data once when function', () => {
+
+            let count = 0;
+            const update = () => {
+
+                ++count;
+                return { a: 1 };
+            };
+
+            const emitter = new Podium.Podium({ name: 'test' });
+
+            let received = 0;
+            emitter.on({ name: 'test', filter: 'a' }, (data) => {
+
+                ++received;
+                expect(data).to.equal({ a: 1 });
+            });
+
+            emitter.on({ name: 'test', filter: 'a' }, (data) => {
+
+                ++received;
+                expect(data).to.equal({ a: 1 });
+            });
+
+            emitter.gauge({ name: 'test', tags: ['a'] }, update);
+            emitter.gauge({ name: 'test', tags: ['b'] }, update);
+
+            expect(received).to.equal(2);
+            expect(count).to.equal(1);
+        });
+
+        it('generates function data', () => {
+
+            const inner = () => 5;
+            let count = 0;
+            const update = () => {
+
+                ++count;
+                return inner;
+            };
+
+            const emitter = new Podium.Podium({ name: 'test' });
+
+            let received = 0;
+            const handler = (data) => {
+
+                ++received;
+                expect(data).to.equal(inner);
+            };
+
+            emitter.on('test', handler);
+            emitter.on('test', handler);
+
+            emitter.gauge('test', update);
+
+            expect(count).to.equal(1);
+            expect(received).to.equal(2);
+        });
+
+        it('clones data for every handler', async () => {
+
+            const update = { a: 1 };
+
+            const emitter = new Podium.Podium({ name: 'test', clone: true });
+            const once = emitter.once('test');
+
+            emitter.gauge('test', update);
+
+            const [data] = await once;
+            expect(data).to.not.shallow.equal(update);
+            expect(data).to.equal(update);
+        });
+
+        it('spreads data', { plan: 1 }, () => {
+
+            const emitter = new Podium.Podium({ name: 'test', spread: true });
+            emitter.on('test', (a, b, c) => {
+
+                expect({ a, b, c }).to.equal({ a: 1, b: 2, c: 3 });
+            });
+
+            emitter.gauge('test', [1, 2, 3]);
+        });
+
+        it('spreads data (function)', { plan: 1 }, () => {
+
+            const emitter = new Podium.Podium({ name: 'test', spread: true });
+            emitter.on('test', (a, b, c) => {
+
+                expect({ a, b, c }).to.equal({ a: 1, b: 2, c: 3 });
+            });
+
+            emitter.gauge('test', () => [1, 2, 3]);
+        });
+
+        it('overrides spread data on once with promise', async () => {
+
+            const emitter = new Podium.Podium({ name: 'test', spread: true });
+            const once = emitter.once('test');
+            emitter.gauge('test', [1, 2, 3]);
+            expect(await once).to.equal([1, 2, 3]);
+        });
+
+        it('adds tags', { plan: 1 }, () => {
+
+            const emitter = new Podium.Podium({ name: 'test', tags: true });
+            emitter.on('test', (data, tags) => {
+
+                expect({ data, tags }).to.equal({ data: [1, 2, 3], tags: { a: true, b: true } });
+            });
+
+            emitter.gauge({ name: 'test', tags: ['a', 'b'] }, [1, 2, 3]);
+        });
+
+        it('adds tags (spread)', { plan: 2 }, () => {
+
+            const emitter = new Podium.Podium({ name: 'test', tags: true, spread: true });
+            emitter.on('test', (a, b, c, tags, ...rest) => {
+
+                expect({ a, b, c, tags }).to.equal({ a: 1, b: 2, c: 3, tags: { a: true, b: true } });
+                expect(rest).to.have.length(0);
+            });
+
+            emitter.gauge({ name: 'test', tags: ['a', 'b'] }, [1, 2, 3]);
+        });
+
+        it('adds tags for multiple listeners (spread)', { plan: 4 }, () => {
+
+            const emitter = new Podium.Podium({ name: 'test', tags: true, spread: true });
+            emitter.on('test', (a, b, c, tags, ...rest) => {
+
+                expect({ a, b, c, tags }).to.equal({ a: 1, b: 2, c: 3, tags: { a: true, b: true } });
+                expect(rest).to.have.length(0);
+            });
+            emitter.on('test', (a, b, c, tags, ...rest) => {
+
+                expect({ a, b, c, tags }).to.equal({ a: 1, b: 2, c: 3, tags: { a: true, b: true } });
+                expect(rest).to.have.length(0);
+            });
+
+            emitter.gauge({ name: 'test', tags: ['a', 'b'] }, [1, 2, 3]);
+        });
+
+        it('send no tags on channel with tags enabled', () => {
+
+            const emitter = new Podium.Podium({ name: 'test', tags: true });
+            emitter.on('test', (data, tags) => {
+
+                expect({ data, tags }).to.equal({ data: [1, 2, 3], tags: undefined });
+            });
+
+            emitter.gauge({ name: 'test' }, [1, 2, 3]);
+        });
+
+        it('errors on unknown channel', async () => {
+
+            const emitter = new Podium.Podium({ name: 'test', channels: ['a', 'b'] });
+            emitter.on('test', Hoek.ignore);
+
+            await expect(emitter.gauge('test')).to.not.reject();
+            await expect(emitter.gauge({ name: 'test', channel: 'a' })).to.not.reject();
+            await expect(emitter.gauge({ name: 'test', channel: 'c' })).to.reject('Unknown c channel');
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -619,6 +619,23 @@ describe('Podium', () => {
             emitter.emit('test', null);
             expect(handled).to.equal(1);
         });
+
+        it('is aliased by off()', () => {
+
+            const emitter = new Podium.Podium('test');
+            let handled = 0;
+            const handler = () => {
+
+                handled++;
+            };
+
+            emitter.addListener('test', handler);
+
+            emitter.emit('test', null);
+            emitter.off('test', handler);
+            emitter.emit('test', null);
+            expect(handled).to.equal(1);
+        });
     });
 
     describe('removeAllListeners()', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -41,6 +41,22 @@ expect.error(podium.emit({ name: 123 }));
 expect.error(podium.emit({ name: 'test', channel: 123 }));
 expect.error(podium.emit({ name: 'test', tags: 123 }));
 
+// gauge()
+
+expect.type<Promise<PromiseSettledResult<unknown>[]>>(podium.gauge('test'));
+expect.type<Promise<PromiseSettledResult<string>[]>>(podium.gauge<string>('test'));
+expect.type<Promise<PromiseSettledResult<unknown>[]>>(podium.gauge('test', { data: true }));
+expect.type<Promise<PromiseSettledResult<unknown>[]>>(podium.gauge({ name: 'test', channel: 'a', tags: 'b' }, { data: true }));
+expect.type<Promise<PromiseSettledResult<unknown>[]>>(podium.gauge({ name: 'test', tags: ['b'] }));
+expect.type<Promise<PromiseSettledResult<unknown>[]>>(podium.gauge({ name: 'test', tags: { b: true } }));
+
+expect.error(podium.gauge());
+expect.error(podium.gauge(123));
+expect.error(podium.gauge({ channel: 'a' }));
+expect.error(podium.gauge({ name: 123 }));
+expect.error(podium.gauge({ name: 'test', channel: 123 }));
+expect.error(podium.gauge({ name: 'test', tags: 123 }));
+
 // on()
 
 expect.type<Podium>(podium.on('test', function () { this instanceof Podium; }));


### PR DESCRIPTION
In #73 we determined we would like to add a method `gauge()` to replace the functionality that has been removed from `emit()` in #76.  In v5 you cannot `await` the result of `emit()`, but you can `await` the result of `gauge()` and it will resolve with an array of results of all event listeners that have run using `Promise.allSettled()`.  The name "gauge" is meant to evoke the idea of "gauging" the reaction of a crowd from the podium.

This PR also includes the method `podium.off()` to alias `podium.removeListener()`, which parallel `podium.on()`/`addListener()`.  Lastly, I fixed some broken links in the docs.