### PR TITLE
Upgrade deps for node v14+

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2016-2020, Sideway Inc, and project contributors  
+Copyright (c) 2016-2022, Project contributors
+Copyright (c) 2016-2020, Sideway Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "^25.0.0",
+    "@hapi/lab": "^25.0.1",
     "@types/node": "^17.0.31",
-    "typescript": "^4.6.4"
+    "typescript": "~4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x",
-    "@hapi/teamwork": "5.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/teamwork": "^6.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
+    "@hapi/lab": "^25.0.0",
     "@types/node": "^17.0.31",
-    "typescript": "~4.4.4"
+    "typescript": "^4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",


### PR DESCRIPTION
Upgrade hoek, teamwork, validate, lab, code, and typescript for node v14+ support.

If this looks good, this will be the last work going into podium v5.